### PR TITLE
Ensure POC users page sends CSRF token with POST requests

### DIFF
--- a/templates/poc/onboarding.html
+++ b/templates/poc/onboarding.html
@@ -304,6 +304,22 @@
         const previewRefresh = document.getElementById('previewRefresh');
         const sharedOutput = document.getElementById('sharedOutput');
 
+        function getCSRFToken() {
+            const cookieString = document.cookie;
+            if (!cookieString) return null;
+            const cookies = cookieString.split(';').map((cookie) => cookie.trim());
+            const csrfCookie = cookies.find((cookie) => cookie.startsWith('csrftoken='));
+            return csrfCookie ? csrfCookie.substring('csrftoken='.length) : null;
+        }
+
+        function buildJsonHeaders(extra = {}) {
+            return {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCSRFToken(),
+                ...extra,
+            };
+        }
+
         function updateTokenPreview() {
             previewAccess.textContent = tokens.access || '(none)';
             previewRefresh.textContent = tokens.refresh || '(none)';
@@ -350,7 +366,7 @@
             try {
                 const response = await fetch(ENDPOINTS.login, {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: buildJsonHeaders(),
                     body: JSON.stringify(payload),
                 });
                 const data = await handleResponse(response);
@@ -377,7 +393,7 @@
             try {
                 const response = await fetch(ENDPOINTS.refresh, {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: buildJsonHeaders(),
                     body: JSON.stringify({ refresh: tokens.refresh }),
                 });
                 const data = await handleResponse(response);
@@ -410,7 +426,7 @@
             try {
                 const response = await fetch(ENDPOINTS.register, {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: buildJsonHeaders(),
                     body: JSON.stringify(payload),
                 });
                 const data = await handleResponse(response);
@@ -438,7 +454,7 @@
             try {
                 const response = await fetch(ENDPOINTS.register, {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: buildJsonHeaders(),
                     body: JSON.stringify(payload),
                 });
                 const data = await handleResponse(response);
@@ -470,10 +486,9 @@
             try {
                 const response = await fetch(ENDPOINTS.athletes, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
+                    headers: buildJsonHeaders({
                         Authorization: `Bearer ${tokens.access}`,
-                    },
+                    }),
                     body: JSON.stringify(payload),
                 });
                 const data = await handleResponse(response);
@@ -503,10 +518,9 @@
             try {
                 const response = await fetch(ENDPOINTS.organisations, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
+                    headers: buildJsonHeaders({
                         Authorization: `Bearer ${tokens.access}`,
-                    },
+                    }),
                     body: JSON.stringify(payload),
                 });
                 const data = await handleResponse(response);
@@ -532,10 +546,9 @@
             try {
                 const response = await fetch(ENDPOINTS.collaborators(organisationId), {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
+                    headers: buildJsonHeaders({
                         Authorization: `Bearer ${tokens.access}`,
-                    },
+                    }),
                     body: JSON.stringify(payload),
                 });
                 const data = await handleResponse(response);

--- a/templates/poc/onboarding.html
+++ b/templates/poc/onboarding.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Onboarding POC • Sponsors Club</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="csrf-token" content="{{ csrf_token }}" />
     <style>
         :root {
             color-scheme: light;
@@ -300,24 +301,37 @@
         };
 
         const tokens = { access: null, refresh: null };
+        const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+        const csrfFromMeta = csrfMeta ? csrfMeta.getAttribute('content') : null;
         const previewAccess = document.getElementById('previewAccess');
         const previewRefresh = document.getElementById('previewRefresh');
         const sharedOutput = document.getElementById('sharedOutput');
 
         function getCSRFToken() {
             const cookieString = document.cookie;
-            if (!cookieString) return null;
-            const cookies = cookieString.split(';').map((cookie) => cookie.trim());
-            const csrfCookie = cookies.find((cookie) => cookie.startsWith('csrftoken='));
-            return csrfCookie ? csrfCookie.substring('csrftoken='.length) : null;
+            if (cookieString) {
+                const cookies = cookieString.split(';').map((cookie) => cookie.trim());
+                const csrfCookie = cookies.find((cookie) => cookie.startsWith('csrftoken='));
+                if (csrfCookie) {
+                    return csrfCookie.substring('csrftoken='.length);
+                }
+            }
+            if (csrfFromMeta && csrfFromMeta !== 'NOTPROVIDED') {
+                return csrfFromMeta;
+            }
+            return null;
         }
 
         function buildJsonHeaders(extra = {}) {
-            return {
+            const headers = {
                 'Content-Type': 'application/json',
-                'X-CSRFToken': getCSRFToken(),
                 ...extra,
             };
+            const csrfToken = getCSRFToken();
+            if (csrfToken) {
+                headers['X-CSRFToken'] = csrfToken;
+            }
+            return headers;
         }
 
         function updateTokenPreview() {
@@ -377,6 +391,7 @@
                     method: 'POST',
                     headers: buildJsonHeaders(),
                     body: JSON.stringify(payload),
+                    credentials: 'same-origin',
                 });
                 const data = await handleResponse(response);
                 if (response.ok) {
@@ -407,6 +422,7 @@
                     method: 'POST',
                     headers: buildJsonHeaders(),
                     body: JSON.stringify({ refresh: tokens.refresh }),
+                    credentials: 'same-origin',
                 });
                 const data = await handleResponse(response);
                 if (response.ok) {
@@ -441,6 +457,7 @@
                     method: 'POST',
                     headers: buildJsonHeaders(),
                     body: JSON.stringify(payload),
+                    credentials: 'same-origin',
                 });
                 const data = await handleResponse(response);
                 if (response.ok) {
@@ -474,6 +491,7 @@
                     method: 'POST',
                     headers: buildJsonHeaders(),
                     body: JSON.stringify(payload),
+                    credentials: 'same-origin',
                 });
                 const data = await handleResponse(response);
                 if (response.ok) {
@@ -513,6 +531,7 @@
                         Authorization: `Bearer ${tokens.access}`,
                     }),
                     body: JSON.stringify(payload),
+                    credentials: 'same-origin',
                 });
                 const data = await handleResponse(response);
                 let output = data;
@@ -557,6 +576,7 @@
                         Authorization: `Bearer ${tokens.access}`,
                     }),
                     body: JSON.stringify(payload),
+                    credentials: 'same-origin',
                 });
                 const data = await handleResponse(response);
                 let output = data;
@@ -597,6 +617,7 @@
                         Authorization: `Bearer ${tokens.access}`,
                     }),
                     body: JSON.stringify(payload),
+                    credentials: 'same-origin',
                 });
                 const data = await handleResponse(response);
                 let output = data;
@@ -621,7 +642,7 @@
 
         async function fetchSports() {
             try {
-                const response = await fetch(ENDPOINTS.sports);
+                const response = await fetch(ENDPOINTS.sports, { credentials: 'same-origin' });
                 const data = await handleResponse(response);
                 if (!response.ok) {
                     renderOutput(data);

--- a/templates/poc/onboarding.html
+++ b/templates/poc/onboarding.html
@@ -325,6 +325,12 @@
             previewRefresh.textContent = tokens.refresh || '(none)';
         }
 
+        function resetTokens() {
+            tokens.access = null;
+            tokens.refresh = null;
+            updateTokenPreview();
+        }
+
         function setStatus(id, text) {
             const node = document.getElementById(id);
             if (node) node.textContent = text;
@@ -349,7 +355,10 @@
         function requireAccessToken(statusId) {
             if (!tokens.access) {
                 setStatus(statusId, 'Missing access token');
-                renderOutput({ error: 'Authenticate first to obtain an access token.' });
+                renderOutput({
+                    error: 'Authenticate with the correct account before continuing.',
+                    hint: 'After registering a new user, sign in with that account to refresh the JWT tokens.',
+                });
                 return false;
             }
             return true;
@@ -374,8 +383,11 @@
                     tokens.access = data.access || null;
                     tokens.refresh = data.refresh || null;
                     updateTokenPreview();
+                    setStatus('loginStatus', 'Authenticated');
+                } else {
+                    resetTokens();
+                    setStatus('loginStatus', `Error ${response.status}`);
                 }
-                setStatus('loginStatus', response.ok ? 'Authenticated' : `Error ${response.status}`);
                 renderOutput(data);
             } catch (error) {
                 setStatus('loginStatus', 'Network error');
@@ -402,6 +414,7 @@
                     updateTokenPreview();
                     setStatus('loginStatus', 'Access token refreshed');
                 } else {
+                    resetTokens();
                     setStatus('loginStatus', `Error ${response.status}`);
                 }
                 renderOutput(data);
@@ -430,7 +443,12 @@
                     body: JSON.stringify(payload),
                 });
                 const data = await handleResponse(response);
-                setStatus('agentRegisterStatus', response.ok ? 'Agent registered' : `Error ${response.status}`);
+                if (response.ok) {
+                    resetTokens();
+                    setStatus('agentRegisterStatus', 'Agent registered (login required)');
+                } else {
+                    setStatus('agentRegisterStatus', `Error ${response.status}`);
+                }
                 renderOutput(data);
             } catch (error) {
                 setStatus('agentRegisterStatus', 'Network error');
@@ -458,7 +476,12 @@
                     body: JSON.stringify(payload),
                 });
                 const data = await handleResponse(response);
-                setStatus('orgRegisterStatus', response.ok ? 'Collaborator registered' : `Error ${response.status}`);
+                if (response.ok) {
+                    resetTokens();
+                    setStatus('orgRegisterStatus', 'Collaborator registered (login required)');
+                } else {
+                    setStatus('orgRegisterStatus', `Error ${response.status}`);
+                }
                 renderOutput(data);
             } catch (error) {
                 setStatus('orgRegisterStatus', 'Network error');
@@ -492,8 +515,20 @@
                     body: JSON.stringify(payload),
                 });
                 const data = await handleResponse(response);
+                let output = data;
+                if (
+                    response.status === 403 &&
+                    output &&
+                    typeof output === 'object' &&
+                    output.detail === 'You do not have permission to perform this action.'
+                ) {
+                    output = {
+                        ...output,
+                        hint: 'This action is reserved for agent accounts. After creating an agent user, sign in with that account to refresh the tokens.',
+                    };
+                }
                 setStatus('athleteStatus', response.ok ? 'Athlete created' : `Error ${response.status}`);
-                renderOutput(data);
+                renderOutput(output);
             } catch (error) {
                 setStatus('athleteStatus', 'Network error');
                 renderOutput({ error: error.message });
@@ -524,8 +559,20 @@
                     body: JSON.stringify(payload),
                 });
                 const data = await handleResponse(response);
+                let output = data;
+                if (
+                    response.status === 403 &&
+                    output &&
+                    typeof output === 'object' &&
+                    output.detail === 'You do not have permission to perform this action.'
+                ) {
+                    output = {
+                        ...output,
+                        hint: 'Only collaborator owner accounts can create organisations. Sign in with the owner account you just registered to continue.',
+                    };
+                }
                 setStatus('organisationStatus', response.ok ? 'Organisation created' : `Error ${response.status}`);
-                renderOutput(data);
+                renderOutput(output);
             } catch (error) {
                 setStatus('organisationStatus', 'Network error');
                 renderOutput({ error: error.message });
@@ -552,8 +599,20 @@
                     body: JSON.stringify(payload),
                 });
                 const data = await handleResponse(response);
+                let output = data;
+                if (
+                    response.status === 403 &&
+                    output &&
+                    typeof output === 'object' &&
+                    output.detail === 'You do not have permission to perform this action.'
+                ) {
+                    output = {
+                        ...output,
+                        hint: 'Collaborator invitations require the organisation owner account. Sign in with the owner credentials before trying again.',
+                    };
+                }
                 setStatus('collaboratorStatus', response.ok ? 'Collaborator added' : `Error ${response.status}`);
-                renderOutput(data);
+                renderOutput(output);
             } catch (error) {
                 setStatus('collaboratorStatus', 'Network error');
                 renderOutput({ error: error.message });

--- a/templates/poc/users.html
+++ b/templates/poc/users.html
@@ -108,6 +108,14 @@
             refresh: null,
         };
 
+        function getCSRFToken() {
+            const cookieString = document.cookie;
+            if (!cookieString) return null;
+            const cookies = cookieString.split(';').map((cookie) => cookie.trim());
+            const csrfCookie = cookies.find((cookie) => cookie.startsWith('csrftoken='));
+            return csrfCookie ? csrfCookie.substring('csrftoken='.length) : null;
+        }
+
         function setStatus(id, text) {
             document.getElementById(id).textContent = text;
         }
@@ -145,7 +153,10 @@
             try {
                 const response = await fetch(REGISTER_URL, {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': getCSRFToken(),
+                    },
                     body: JSON.stringify(payload),
                 });
                 const data = await handleJsonResponse(response);
@@ -168,7 +179,10 @@
             try {
                 const response = await fetch(LOGIN_URL, {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': getCSRFToken(),
+                    },
                     body: JSON.stringify(authPayload),
                 });
                 const data = await handleJsonResponse(response);
@@ -195,7 +209,10 @@
             try {
                 const response = await fetch(REFRESH_URL, {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': getCSRFToken(),
+                    },
                     body: JSON.stringify({ refresh: tokens.refresh }),
                 });
                 const data = await handleJsonResponse(response);

--- a/templates/poc/users.html
+++ b/templates/poc/users.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Users API POC</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="csrf-token" content="{{ csrf_token }}" />
     <style>
         body { margin: 0; font-family: Arial, sans-serif; display: flex; min-height: 100vh; }
         aside { width: 260px; background: #231127; color: #f9fafb; padding: 24px; box-sizing: border-box; }
@@ -107,13 +108,34 @@
             access: null,
             refresh: null,
         };
+        const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+        const csrfFromMeta = csrfMeta ? csrfMeta.getAttribute('content') : null;
 
         function getCSRFToken() {
             const cookieString = document.cookie;
-            if (!cookieString) return null;
-            const cookies = cookieString.split(';').map((cookie) => cookie.trim());
-            const csrfCookie = cookies.find((cookie) => cookie.startsWith('csrftoken='));
-            return csrfCookie ? csrfCookie.substring('csrftoken='.length) : null;
+            if (cookieString) {
+                const cookies = cookieString.split(';').map((cookie) => cookie.trim());
+                const csrfCookie = cookies.find((cookie) => cookie.startsWith('csrftoken='));
+                if (csrfCookie) {
+                    return csrfCookie.substring('csrftoken='.length);
+                }
+            }
+            if (csrfFromMeta && csrfFromMeta !== 'NOTPROVIDED') {
+                return csrfFromMeta;
+            }
+            return null;
+        }
+
+        function buildJsonHeaders(extra = {}) {
+            const headers = {
+                'Content-Type': 'application/json',
+                ...extra,
+            };
+            const csrfToken = getCSRFToken();
+            if (csrfToken) {
+                headers['X-CSRFToken'] = csrfToken;
+            }
+            return headers;
         }
 
         function setStatus(id, text) {
@@ -159,11 +181,9 @@
             try {
                 const response = await fetch(REGISTER_URL, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRFToken': getCSRFToken(),
-                    },
+                    headers: buildJsonHeaders(),
                     body: JSON.stringify(payload),
+                    credentials: 'same-origin',
                 });
                 const data = await handleJsonResponse(response);
                 if (response.ok) {
@@ -190,11 +210,9 @@
             try {
                 const response = await fetch(LOGIN_URL, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRFToken': getCSRFToken(),
-                    },
+                    headers: buildJsonHeaders(),
                     body: JSON.stringify(authPayload),
+                    credentials: 'same-origin',
                 });
                 const data = await handleJsonResponse(response);
                 if (response.ok) {
@@ -223,11 +241,9 @@
             try {
                 const response = await fetch(REFRESH_URL, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRFToken': getCSRFToken(),
-                    },
+                    headers: buildJsonHeaders(),
                     body: JSON.stringify({ refresh: tokens.refresh }),
+                    credentials: 'same-origin',
                 });
                 const data = await handleJsonResponse(response);
                 if (response.ok) {
@@ -260,6 +276,7 @@
                         headers: {
                             Authorization: `Bearer ${tokens.access}`,
                         },
+                        credentials: 'same-origin',
                     });
                     const data = await handleJsonResponse(response);
                     printResult(data);

--- a/templates/poc/users.html
+++ b/templates/poc/users.html
@@ -125,6 +125,12 @@
             refreshTokenPreview.textContent = tokens.refresh ? tokens.refresh : '(none)';
         }
 
+        function resetTokens() {
+            tokens.access = null;
+            tokens.refresh = null;
+            updateTokenPreview();
+        }
+
         async function handleJsonResponse(response) {
             const contentType = response.headers.get('content-type');
             if (contentType && contentType.includes('application/json')) {
@@ -160,8 +166,13 @@
                     body: JSON.stringify(payload),
                 });
                 const data = await handleJsonResponse(response);
+                if (response.ok) {
+                    resetTokens();
+                    setStatus('registerStatus', 'Created (login required)');
+                } else {
+                    setStatus('registerStatus', 'Error');
+                }
                 printResult(data);
-                setStatus('registerStatus', response.ok ? 'Success' : 'Error');
             } catch (error) {
                 printResult({ error: error.message });
                 setStatus('registerStatus', 'Network error');
@@ -190,9 +201,12 @@
                     tokens.access = data.access || null;
                     tokens.refresh = data.refresh || null;
                     updateTokenPreview();
+                    setStatus('loginStatus', 'Success');
+                } else {
+                    resetTokens();
+                    setStatus('loginStatus', `Error ${response.status}`);
                 }
                 printResult(data);
-                setStatus('loginStatus', response.ok ? 'Success' : 'Error');
             } catch (error) {
                 printResult({ error: error.message });
                 setStatus('loginStatus', 'Network error');
@@ -219,9 +233,12 @@
                 if (response.ok) {
                     tokens.access = data.access || tokens.access;
                     updateTokenPreview();
+                    setStatus('refreshStatus', 'Success');
+                } else {
+                    resetTokens();
+                    setStatus('refreshStatus', `Error ${response.status}`);
                 }
                 printResult(data);
-                setStatus('refreshStatus', response.ok ? 'Success' : 'Error');
             } catch (error) {
                 printResult({ error: error.message });
                 setStatus('refreshStatus', 'Network error');


### PR DESCRIPTION
## Summary
- add a helper to read the csrftoken cookie from document.cookie
- send the X-CSRFToken header with register, login, and refresh POST requests in the POC page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd6e1d9e28832e939515bf2d1723fb