### PR TITLE
Restrict organisation and athlete creation permissions

### DIFF
--- a/core/management/commands/seed.py
+++ b/core/management/commands/seed.py
@@ -84,7 +84,6 @@ class Command(BaseCommand):
             organisations_created = self._create_organisations(
                 faker,
                 organisations,
-                agent_profiles,
             )
             athletes_created = self._create_athletes(
                 faker,
@@ -141,17 +140,25 @@ class Command(BaseCommand):
         self,
         faker: Faker,
         count: int,
-        agent_profiles: list[AgentProfile],
     ) -> list[Organisation]:
-        """Create organisations and assign a random owner from the agent pool."""
+        """Create organisations with dedicated collaborator owners."""
         organisations: list[Organisation] = []
-        if not agent_profiles:
+        if count <= 0:
             return organisations
 
         for _ in range(count):
-            owner = random.choice(agent_profiles)
+            email = faker.unique.email()
+            full_name = faker.name()
+            first_name, _, last_name = full_name.partition(' ')
+            owner = User.objects.create_user(
+                email=email,
+                password=DEFAULT_PASSWORD,
+                first_name=first_name,
+                last_name=last_name,
+                account_type=User.AccountType.COLLABORATOR,
+            )
             organisation = Organisation.objects.create(
-                owner=owner.user,
+                owner=owner,
                 name=faker.unique.company(),
                 sector=faker.job().title(),
                 size=random.choice([choice[0] for choice in Organisation.Size.choices]),
@@ -162,13 +169,11 @@ class Command(BaseCommand):
                 website=faker.url(),
             )
             Collaborator.objects.create(
-                user=owner.user,
+                user=owner,
                 organisation=organisation,
                 role=Collaborator.Role.OWNER,
-                job_title='Owner',
+                job_title=faker.job().title(),
             )
-            owner.user.account_type = User.AccountType.COLLABORATOR
-            owner.user.save(update_fields=['account_type'])
             organisations.append(organisation)
         return organisations
 

--- a/organisations/serializers.py
+++ b/organisations/serializers.py
@@ -70,6 +70,10 @@ class OrganisationCreateSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         """Create the organisation and ensure the requester becomes the owner."""
         user = self.context['request'].user
+        if getattr(user, 'account_type', None) != User.AccountType.COLLABORATOR and not user.is_staff:
+            raise serializers.ValidationError(
+                {'non_field_errors': ['Only collaborator accounts may create organisations.']}
+            )
         organisation = Organisation.objects.create(  # pylint: disable=no-member
             owner=user,
             **validated_data,
@@ -80,8 +84,6 @@ class OrganisationCreateSerializer(serializers.ModelSerializer):
             role=Collaborator.Role.OWNER,
             job_title='Owner',
         )
-        user.account_type = User.AccountType.COLLABORATOR
-        user.save(update_fields=['account_type'])
         return organisation
 
 
@@ -155,6 +157,11 @@ class CollaboratorCreateSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 {'email': 'No user found with this email address.'}
             ) from exc
+
+        if getattr(user, 'account_type', None) != User.AccountType.COLLABORATOR and not user.is_staff:
+            raise serializers.ValidationError(
+                {'email': 'Only collaborator accounts may join organisations.'}
+            )
 
         collaborator = Collaborator.objects.create(  # pylint: disable=no-member
             user=user,

--- a/organisations/tests/test_organisations_api.py
+++ b/organisations/tests/test_organisations_api.py
@@ -110,13 +110,13 @@ def test_organisation_serializer_owner_field(organisations_setup):
 
 @pytest.mark.django_db
 def test_organisation_create_serializer(factory, user_model):
-    """Creating an organisation promotes the creator to owner."""
+    """Creating an organisation persists owner collaborator membership."""
     user = user_model.objects.create_user(
         email='creator@test.com',
         password='pass1234',
         first_name='Creator',
         last_name='User',
-        account_type=user_model.AccountType.AGENT,
+        account_type=user_model.AccountType.COLLABORATOR,
     )
     request = factory.post('/api/organisations/')
     request.user = user
@@ -139,6 +139,32 @@ def test_organisation_create_serializer(factory, user_model):
     assert user.account_type == user_model.AccountType.COLLABORATOR
     assert organisation.owner == user
     assert Collaborator.objects.filter(user=user, organisation=organisation, role=Collaborator.Role.OWNER).exists()
+
+
+@pytest.mark.django_db
+def test_organisation_create_serializer_rejects_agent(factory, user_model):
+    """Serializer validation fails for agent accounts."""
+    user = user_model.objects.create_user(
+        email='agent-creator@test.com',
+        password='pass1234',
+        account_type=user_model.AccountType.AGENT,
+    )
+    request = factory.post('/api/organisations/')
+    request.user = user
+    serializer = OrganisationCreateSerializer(
+        data={
+            'name': 'Blocked Org',
+            'sector': 'Tech',
+            'size': Organisation.Size.SMALL,
+            'budget_min': 1000,
+            'budget_max': 2000,
+            'country': 'FR',
+        },
+        context={'request': request},
+    )
+    assert serializer.is_valid(), serializer.errors
+    with pytest.raises(serializers.ValidationError):
+        serializer.save()
 
 
 @pytest.mark.django_db
@@ -198,8 +224,12 @@ def test_collaborator_create_serializer_missing_user(organisation):
 
 @pytest.mark.django_db
 def test_collaborator_create_serializer_success(organisation, user_model):
-    """Successfully add an existing user as a collaborator."""
-    invitee = user_model.objects.create_user(email='invitee@test.com', password='pass1234')
+    """Successfully add an existing collaborator account to the organisation."""
+    invitee = user_model.objects.create_user(
+        email='invitee@test.com',
+        password='pass1234',
+        account_type=user_model.AccountType.COLLABORATOR,
+    )
     serializer = CollaboratorCreateSerializer(
         data={'email': invitee.email, 'role': Collaborator.Role.MEMBER, 'job_title': 'Analyst'},
         context={'organisation': organisation},
@@ -208,6 +238,23 @@ def test_collaborator_create_serializer_success(organisation, user_model):
     collaborator = serializer.save()
     assert collaborator.user == invitee
     assert collaborator.organisation == organisation
+
+
+@pytest.mark.django_db
+def test_collaborator_create_serializer_rejects_agent_accounts(organisation, user_model):
+    """Agent accounts cannot be invited to collaborate with an organisation."""
+    invitee = user_model.objects.create_user(
+        email='agent-invite@test.com',
+        password='pass1234',
+        account_type=user_model.AccountType.AGENT,
+    )
+    serializer = CollaboratorCreateSerializer(
+        data={'email': invitee.email, 'role': Collaborator.Role.MEMBER, 'job_title': 'Analyst'},
+        context={'organisation': organisation},
+    )
+    assert serializer.is_valid(), serializer.errors
+    with pytest.raises(serializers.ValidationError):
+        serializer.save()
 
 
 @pytest.mark.django_db
@@ -422,7 +469,11 @@ def test_collaborator_list_action(owner_client, organisation):
 @pytest.mark.django_db
 def test_add_collaborator_success(owner_client, organisation, user_model):
     """Owners can invite existing users as collaborators."""
-    invitee = user_model.objects.create_user(email='invite2@test.com', password='pass1234')
+    invitee = user_model.objects.create_user(
+        email='invite2@test.com',
+        password='pass1234',
+        account_type=user_model.AccountType.COLLABORATOR,
+    )
     url = reverse('organisation-add-collaborator', kwargs={'pk': organisation.id})
     response = owner_client.post(url, {
         'email': invitee.email,
@@ -431,6 +482,24 @@ def test_add_collaborator_success(owner_client, organisation, user_model):
     }, format='json')
     assert response.status_code == status.HTTP_201_CREATED
     assert Collaborator.objects.filter(user=invitee, organisation=organisation).exists()
+
+
+@pytest.mark.django_db
+def test_add_collaborator_rejects_agent(owner_client, organisation, user_model):
+    """Inviting an agent account as collaborator returns a validation error."""
+    invitee = user_model.objects.create_user(
+        email='agent-collab@test.com',
+        password='pass1234',
+        account_type=user_model.AccountType.AGENT,
+    )
+    url = reverse('organisation-add-collaborator', kwargs={'pk': organisation.id})
+    response = owner_client.post(url, {
+        'email': invitee.email,
+        'role': Collaborator.Role.MEMBER,
+        'job_title': 'Analyst',
+    }, format='json')
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'email' in response.data
 
 
 @pytest.mark.django_db

--- a/organisations/tests/test_organisations_api.py
+++ b/organisations/tests/test_organisations_api.py
@@ -39,15 +39,14 @@ def owner_client(owner_user):
 
 @pytest.fixture
 def collaborator_user(user_model):
-    """Create and return an agent user who can become a collaborator."""
+    """Create and return a collaborator account for membership tests."""
     user = user_model.objects.create_user(
         email='collab@test.com',
         password='pass1234',
         first_name='Collab',
         last_name='User',
-        account_type=user_model.AccountType.AGENT,
+        account_type=user_model.AccountType.COLLABORATOR,
     )
-    AgentProfile.objects.create(user=user, display_name='Collaborator Agent')
     return user
 
 
@@ -332,8 +331,8 @@ def test_organisation_retrieve(owner_client, organisation):
 
 
 @pytest.mark.django_db
-def test_organisation_create_view(user_model):
-    """API view creates an organisation and promotes the requester."""
+def test_organisation_create_forbidden_for_agent(user_model):
+    """Agents cannot create organisations through the API endpoint."""
     user = user_model.objects.create_user(
         email='maker@test.com',
         password='pass1234',
@@ -353,12 +352,42 @@ def test_organisation_create_view(user_model):
         'country': 'FR',
     }
     response = client.post(list_url, payload, format='json')
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert not Organisation.objects.filter(name=payload['name']).exists()
+
+
+@pytest.mark.django_db
+def test_organisation_create_view_collaborator_success(user_model):
+    """Collaborator accounts can create organisations and become owners."""
+    user = user_model.objects.create_user(
+        email='collab-maker@test.com',
+        password='pass1234',
+        first_name='CollabMaker',
+        last_name='User',
+        account_type=user_model.AccountType.COLLABORATOR,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    list_url = reverse('organisation-list')
+    payload = {
+        'name': 'Collaborator Org',
+        'sector': 'Media',
+        'size': Organisation.Size.MEDIUM,
+        'budget_min': 300,
+        'budget_max': 900,
+        'country': 'FR',
+    }
+    response = client.post(list_url, payload, format='json')
     assert response.status_code == status.HTTP_201_CREATED
-    user.refresh_from_db()
-    assert user.account_type == user_model.AccountType.COLLABORATOR
     organisation = Organisation.objects.get(name=payload['name'])
     assert organisation.owner == user
-    assert Collaborator.objects.filter(user=user, organisation__name='API Org', role=Collaborator.Role.OWNER).exists()
+    user.refresh_from_db()
+    assert user.account_type == user_model.AccountType.COLLABORATOR
+    assert Collaborator.objects.filter(
+        user=user,
+        organisation=organisation,
+        role=Collaborator.Role.OWNER,
+    ).exists()
 
 
 @pytest.mark.django_db

--- a/organisations/views.py
+++ b/organisations/views.py
@@ -53,6 +53,7 @@ class OrganisationViewSet(  # pylint: disable=too-many-ancestors
             'partial_update': self._owner_permissions,
             'collaborators': self._collaborator_permissions,
             'add_collaborator': self._collaborator_permissions,
+            'create': self._organisation_account_permissions,
             'list': self._organisation_account_permissions,
             'remove_collaborator': lambda: [permissions.IsAuthenticated()],
         }


### PR DESCRIPTION
## Summary
- require collaborator accounts (or staff) when creating organisations via the API
- update organisation API tests to cover the new collaborator flow and ensure agents are blocked
- adjust collaborator fixtures to reflect collaborator accounts

## Testing
- pytest organisations/tests/test_organisations_api.py athletes/tests/test_athletes_api.py

------
https://chatgpt.com/codex/tasks/task_e_68cdaa77edc8832e8228fff9f09ccc29