### PR TITLE
Stop auto-creating organisation for collaborator sign-up

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -2,12 +2,10 @@
 
 # pylint: disable=missing-class-docstring,too-few-public-methods,duplicate-code
 
-from decimal import Decimal
-
 from django.db import transaction
 from rest_framework import serializers
 
-from organisations.models import Collaborator, Organisation
+from organisations.models import Collaborator
 
 from .models import AgentProfile, User
 
@@ -92,8 +90,8 @@ class RegisterSerializer(serializers.ModelSerializer):  # pylint: disable=too-fe
     def create(self, validated_data):
         """Create a user and any related agent or collaborator records."""
         display_name = validated_data.pop('display_name', None)
-        organisation_name = validated_data.pop('organisation_name', None)
-        job_title = validated_data.pop('job_title', None)
+        validated_data.pop('organisation_name', None)
+        validated_data.pop('job_title', None)
         password = validated_data.pop('password')
         user = User.objects.create_user(password=password, **validated_data)
         if user.account_type == User.AccountType.AGENT:
@@ -101,26 +99,6 @@ class RegisterSerializer(serializers.ModelSerializer):  # pylint: disable=too-fe
             AgentProfile.objects.create(  # pylint: disable=no-member
                 user=user,
                 display_name=display_name or default_display_name,
-            )
-        else:
-            default_org_name = (
-                organisation_name
-                or f"Organisation {user.first_name or user.last_name or user.email.split('@')[0]}"
-            )
-            organisation = Organisation.objects.create(  # pylint: disable=no-member
-                name=default_org_name,
-                owner=user,
-                sector='Unknown',
-                size=Organisation.Size.SMALL,
-                budget_min=Decimal('0'),
-                budget_max=Decimal('0'),
-                country='Unknown',
-            )
-            Collaborator.objects.create(  # pylint: disable=no-member
-                user=user,
-                organisation=organisation,
-                role=Collaborator.Role.OWNER,
-                job_title=job_title or 'Owner',
             )
         return user
 

--- a/users/tests/test_user_api.py
+++ b/users/tests/test_user_api.py
@@ -64,7 +64,7 @@ def test_register_agent_success(api_client, user_model):
 
 
 @pytest.mark.django_db
-def test_register_organisation_success(api_client, user_model):
+def test_register_collaborator_success(api_client, user_model):
     url = reverse('users:register')
     payload = {
         'email': 'org@example.com',
@@ -79,13 +79,8 @@ def test_register_organisation_success(api_client, user_model):
     assert response.status_code == 201
     user = user_model.objects.get(email='org@example.com')
     assert user.account_type == user_model.AccountType.COLLABORATOR
-    organisation = Organisation.objects.get(owner=user)
-    assert organisation.name == 'Org Example'
-    assert Collaborator.objects.filter(
-        user=user,
-        organisation=organisation,
-        role=Collaborator.Role.OWNER,
-    ).exists()
+    assert not Organisation.objects.filter(owner=user).exists()
+    assert not Collaborator.objects.filter(user=user).exists()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- avoid creating an organisation and collaborator membership when a collaborator registers
- adjust collaborator registration test to assert no organisation or membership is created

## Testing
- pytest users/tests/test_user_api.py

------
https://chatgpt.com/codex/tasks/task_e_68cdb53bf6ec832eb57756b0e91bb4a9