### PR TITLE
Add agent-only endpoint to list owned athletes

### DIFF
--- a/athletes/tests/test_athletes_api.py
+++ b/athletes/tests/test_athletes_api.py
@@ -200,6 +200,45 @@ def test_sport_serializer(sport):
 
 
 @pytest.mark.django_db
+def test_my_athletes_view_returns_only_owned_athletes(
+    api_client, agent_user, athlete, sport, other_agent_user
+):
+    Athlete.objects.create(
+        sport=sport,
+        agent=other_agent_user.agent_profile,
+        full_name="Jane Smith",
+        birth_date=date(1992, 2, 2),
+        nationality="US",
+        bio="Other bio",
+        social_links={"twitter": "jane_smith"},
+    )
+
+    api_client.force_authenticate(agent_user)
+    url = reverse("my-athletes")
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["id"] == str(athlete.id)
+
+
+@pytest.mark.django_db
+def test_my_athletes_view_denies_non_agent_access(api_client, user_model):
+    collaborator = user_model.objects.create_user(
+        email="collab@example.com",
+        password="pass1234",
+        account_type=user_model.AccountType.COLLABORATOR,
+    )
+
+    api_client.force_authenticate(collaborator)
+    url = reverse("my-athletes")
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
 def test_athlete_list_requires_authentication(athlete):
     client = APIClient()
     url = reverse("athlete-list")

--- a/athletes/urls.py
+++ b/athletes/urls.py
@@ -3,12 +3,13 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from .views import AthleteViewSet, SportListView
+from .views import AthleteViewSet, MyAthletesView, SportListView
 
 router = DefaultRouter()
 router.register(r"athletes", AthleteViewSet, basename="athlete")
 
 urlpatterns = [
     path("", include(router.urls)),
+    path("me/athletes/", MyAthletesView.as_view(), name="my-athletes"),
     path("sports/", SportListView.as_view(), name="sports-list"),
 ]

--- a/athletes/views.py
+++ b/athletes/views.py
@@ -1,8 +1,10 @@
 """Views for athlete CRUD operations and sport listings."""
 
-from rest_framework import permissions, viewsets
+from rest_framework import generics, permissions, viewsets
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from core.permissions import get_agent_profile
 
 from .models import Athlete, Sport
 from .permissions import CanViewAthlete, IsAgentUser, IsAthleteOwner, IsCollaboratorUser
@@ -39,6 +41,23 @@ class AthleteViewSet(viewsets.ModelViewSet):
     def perform_update(self, serializer):
         """Persist changes to an existing athlete instance."""
         serializer.save()
+
+
+class MyAthletesView(generics.ListAPIView):
+    """List the athletes owned by the authenticated agent."""
+
+    serializer_class = AthleteSerializer
+    permission_classes = (permissions.IsAuthenticated, IsAgentUser)
+
+    def get_queryset(self):
+        """Return the queryset restricted to the agent's own athletes."""
+
+        agent_profile = get_agent_profile(self.request.user)
+        if agent_profile is None:
+            return Athlete.objects.none()
+        return Athlete.objects.filter(agent=agent_profile).select_related(
+            "sport", "agent__user"
+        )
 
 
 class SportListView(APIView):

--- a/organisations/tests/test_organisations_api.py
+++ b/organisations/tests/test_organisations_api.py
@@ -169,32 +169,6 @@ def test_organisation_create_serializer_rejects_agent(factory, user_model):
 
 
 @pytest.mark.django_db
-def test_organisation_create_serializer_rejects_agent(factory, user_model):
-    """Serializer validation fails for agent accounts."""
-    user = user_model.objects.create_user(
-        email="agent-creator@test.com",
-        password="pass1234",
-        account_type=user_model.AccountType.AGENT,
-    )
-    request = factory.post("/api/organisations/")
-    request.user = user
-    serializer = OrganisationCreateSerializer(
-        data={
-            "name": "Blocked Org",
-            "sector": "Tech",
-            "size": Organisation.Size.SMALL,
-            "budget_min": 1000,
-            "budget_max": 2000,
-            "country": "FR",
-        },
-        context={"request": request},
-    )
-    assert serializer.is_valid(), serializer.errors
-    with pytest.raises(serializers.ValidationError):
-        serializer.save()
-
-
-@pytest.mark.django_db
 def test_collaborator_serializer_fields(organisations_setup):
     """Collaborator serializer exposes related user metadata."""
     collaborator = organisations_setup["collaborator"]

--- a/organisations/tests/test_organisations_api.py
+++ b/organisations/tests/test_organisations_api.py
@@ -172,22 +172,22 @@ def test_organisation_create_serializer_rejects_agent(factory, user_model):
 def test_organisation_create_serializer_rejects_agent(factory, user_model):
     """Serializer validation fails for agent accounts."""
     user = user_model.objects.create_user(
-        email='agent-creator@test.com',
-        password='pass1234',
+        email="agent-creator@test.com",
+        password="pass1234",
         account_type=user_model.AccountType.AGENT,
     )
-    request = factory.post('/api/organisations/')
+    request = factory.post("/api/organisations/")
     request.user = user
     serializer = OrganisationCreateSerializer(
         data={
-            'name': 'Blocked Org',
-            'sector': 'Tech',
-            'size': Organisation.Size.SMALL,
-            'budget_min': 1000,
-            'budget_max': 2000,
-            'country': 'FR',
+            "name": "Blocked Org",
+            "sector": "Tech",
+            "size": Organisation.Size.SMALL,
+            "budget_min": 1000,
+            "budget_max": 2000,
+            "country": "FR",
         },
-        context={'request': request},
+        context={"request": request},
     )
     assert serializer.is_valid(), serializer.errors
     with pytest.raises(serializers.ValidationError):


### PR DESCRIPTION
## Summary
- add a dedicated view to expose only the authenticated agent's athletes
- register the new route under /api/me/athletes/ for agent access
- cover the endpoint with tests that confirm filtering and permissions
- format the organisations API test module to satisfy ruff formatting

## Testing
- ruff format --check .
- pytest organisations/tests/test_organisations_api.py
- pytest athletes/tests/test_athletes_api.py

------
https://chatgpt.com/codex/tasks/task_e_68ce1b6158a8832ebf58de61178976b8