### PR TITLE
Add docker-compose setup with PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ docker run --rm -p 8000:8000 \
 ```
 `PORT` overrides the Gunicorn bind address, while `scripts/migrate.sh` and `scripts/entrypoint.sh` manage database migrations and server startup inside the container.
 
+### Docker Compose with PostgreSQL
+A `docker-compose.yml` file is available for a full local stack that includes PostgreSQL. It builds the application container,
+waits for the database to become healthy, runs migrations, creates a superuser (using the credentials from the compose file),
+and then launches Gunicorn:
+
+```bash
+docker compose up --build
+```
+
+Override the default database credentials or Django settings by exporting environment variables before running `docker compose`
+or by editing the compose file. The service mounts the repository into the container so code changes are picked up without a
+rebuild. To re-run migrations manually, use:
+
+```bash
+docker compose run --rm web /app/scripts/migrate.sh
+```
+
 ## Database seeding
 Populate a realistic dataset for demos or development:
 ```bash

--- a/core/settings.py
+++ b/core/settings.py
@@ -96,6 +96,17 @@ DATABASES = {
 }
 
 
+if os.environ.get("POSTGRES_DB"):
+    DATABASES["default"] = {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ["POSTGRES_DB"],
+        "USER": os.environ.get("POSTGRES_USER", ""),
+        "PASSWORD": os.environ.get("POSTGRES_PASSWORD", ""),
+        "HOST": os.environ.get("POSTGRES_HOST", "localhost"),
+        "PORT": os.environ.get("POSTGRES_PORT", "5432"),
+    }
+
+
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  web:
+    build: .
+    entrypoint: ["/bin/sh", "-c", "/app/scripts/migrate.sh && /app/scripts/entrypoint.sh"]
+    environment:
+      POSTGRES_DB: sponsors_club
+      POSTGRES_USER: sponsors
+      POSTGRES_PASSWORD: sponsors
+      POSTGRES_HOST: db
+      POSTGRES_PORT: "5432"
+      DJANGO_SUPERUSER_EMAIL: admin@example.com
+      DJANGO_SUPERUSER_PASSWORD: Passw0rd!
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./:/app
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: sponsors_club
+      POSTGRES_USER: sponsors
+      POSTGRES_PASSWORD: sponsors
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sponsors -d sponsors_club"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add a docker-compose configuration that provisions PostgreSQL and runs migrations before starting the app
- allow Django to switch to PostgreSQL automatically when POSTGRES_* environment variables are provided
- document the compose workflow alongside existing container instructions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d426490364832ea17f2a9e26d087a8