### PR TITLE
Ensure pytest uses SQLite database

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -97,7 +97,7 @@ DATABASES = {
 }
 
 
-if os.environ.get("POSTGRES_DB"):
+if os.environ.get("POSTGRES_DB") and not os.environ.get("PYTEST_CURRENT_TEST"):
     DATABASES["default"] = {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": os.environ["POSTGRES_DB"],


### PR DESCRIPTION
## Summary
- keep the default SQLite configuration active when pytest is running so local `.env` Postgres variables do not override it

## Testing
- pytest users/tests/test_user_api.py::test_me_entitlements_collaborator -q

------
https://chatgpt.com/codex/tasks/task_e_68d44e97356c832e8775bfff2156c1f1