### PR TITLE
Add WebSocket infrastructure for realtime updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ and then launches Gunicorn:
 docker compose up --build
 ```
 
+> ℹ️  The `redis` service pulls the image `public.ecr.aws/docker/library/redis:7-alpine`, an AWS-hosted mirror of the official
+> Docker Hub library image. This registry does not require a Docker Hub login, avoiding 401 errors when Hub access is blocked.
+> If you cannot reach any external registry, remove the `REDIS_URL` variable (or override it to blank) and rely on the
+> in-memory channel layer defined in `core/settings.py` for single-process development.
+
 Override the default database credentials or Django settings by exporting environment variables before running `docker compose`
 or by editing the compose file. The service mounts the repository into the container so code changes are picked up without a rebuild. Static assets are collected on startup and served via WhiteNoise; they persist in a dedicated Docker volume so admin
 pages load without 404s even after container restarts. To re-run migrations manually, use:

--- a/core/asgi.py
+++ b/core/asgi.py
@@ -1,16 +1,42 @@
-"""
-ASGI config for core project.
+"""ASGI config for the Sponsors Club project.
 
-It exposes the ASGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/4.2/howto/deployment/asgi/
+The ASGI application exposes both the traditional HTTP interface and the
+WebSocket endpoints used for real-time messaging and notification delivery.
 """
 
 import os
+from importlib import import_module
 
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
 from django.core.asgi import get_asgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
 
-application = get_asgi_application()
+django_asgi_app = get_asgi_application()
+
+
+def _load_websocket_urlpatterns():
+    """Dynamically load websocket URL patterns from installed apps."""
+
+    messaging_routing = import_module("messaging.routing")
+    notifications_routing = import_module("notifications.routing")
+    return (
+        getattr(messaging_routing, "websocket_urlpatterns", [])
+        + getattr(notifications_routing, "websocket_urlpatterns", [])
+    )
+
+
+from core.auth import JWTAuthMiddlewareStack  # noqa: E402  pylint: disable=wrong-import-position
+
+
+application = ProtocolTypeRouter(
+    {
+        "http": django_asgi_app,
+        "websocket": AllowedHostsOriginValidator(
+            JWTAuthMiddlewareStack(
+                URLRouter(_load_websocket_urlpatterns())
+            )
+        ),
+    }
+)

--- a/core/auth.py
+++ b/core/auth.py
@@ -1,0 +1,62 @@
+"""Authentication helpers for ASGI middleware stacks."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from channels.auth import AuthMiddlewareStack
+from channels.db import database_sync_to_async
+from django.contrib.auth.models import AnonymousUser
+from urllib.parse import parse_qs
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+
+class JWTAuthMiddleware:
+    """Populate the connection scope user from a JWT when provided."""
+
+    def __init__(self, inner: Callable):
+        self.inner = inner
+        self.jwt_auth = JWTAuthentication()
+
+    async def __call__(self, scope: Dict, receive, send):  # type: ignore[override]
+        token = self._extract_token(scope)
+        if token:
+            user = await self._get_user(token)
+            if user is not None:
+                scope = dict(scope)
+                scope["user"] = user
+        return await self.inner(scope, receive, send)
+
+    def _extract_token(self, scope: Dict) -> Optional[str]:
+        headers = dict(scope.get("headers", []))
+        authorization = headers.get(b"authorization")
+        if authorization:
+            try:
+                scheme, token = authorization.decode().split(" ", 1)
+            except ValueError:
+                token = ""
+            else:
+                if scheme.lower() == "bearer":
+                    return token.strip()
+        query_string = scope.get("query_string", b"").decode()
+        if query_string:
+            params = parse_qs(query_string)
+            token_values = params.get("token")
+            if token_values:
+                return token_values[0]
+        return None
+
+    @database_sync_to_async
+    def _get_user(self, token: str):
+        try:
+            validated = self.jwt_auth.get_validated_token(token)
+            user = self.jwt_auth.get_user(validated)
+            return user if user.is_authenticated else AnonymousUser()
+        except Exception:  # pragma: no cover - invalid token simply yields anonymous access
+            return None
+
+
+def JWTAuthMiddlewareStack(inner: Callable):
+    """Combine Django's auth stack with optional JWT support."""
+
+    return JWTAuthMiddleware(AuthMiddlewareStack(inner))

--- a/core/settings.py
+++ b/core/settings.py
@@ -3,6 +3,7 @@
 import importlib.util
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 
 try:  # pragma: no cover - fallback path exercised only when dependency missing
     from dotenv import load_dotenv
@@ -198,6 +199,14 @@ _env_cors_origins = [
 
 CORS_ALLOWED_ORIGINS = _env_cors_origins or list(_default_cors_origins)
 CORS_ALLOW_CREDENTIALS = True
+
+# Copy CORS hostnames into ALLOWED_HOSTS so websocket origin checks match.
+_cors_hosts = {
+    parsed.hostname
+    for origin in CORS_ALLOWED_ORIGINS
+    if origin and (parsed := urlparse(origin)).hostname
+}
+ALLOWED_HOSTS = list({*ALLOWED_HOSTS, *(_cors_hosts or set())})
 
 
 AUTH_USER_MODEL = "users.User"

--- a/core/settings.py
+++ b/core/settings.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "channels",
     "rest_framework",
     "django_filters",
     "core.apps.CoreConfig",
@@ -83,6 +84,7 @@ TEMPLATES = [
     },
 ]
 
+ASGI_APPLICATION = "core.asgi.application"
 WSGI_APPLICATION = "core.wsgi.application"
 
 
@@ -199,3 +201,18 @@ EMAIL_VERIFICATION_URL_TEMPLATE = os.environ.get(
     "EMAIL_VERIFICATION_URL_TEMPLATE",
     "",
 )
+
+
+if os.environ.get("REDIS_URL"):
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            "CONFIG": {"hosts": [os.environ["REDIS_URL"]]},
+        }
+    }
+else:
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+        }
+    }

--- a/core/settings.py
+++ b/core/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     "channels",
     "rest_framework",
     "django_filters",
+    "corsheaders",
     "core.apps.CoreConfig",
     "analytics",
     "athletes",
@@ -64,6 +65,7 @@ if DRF_YASG_ENABLED:
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -180,6 +182,22 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
 }
+
+
+_default_cors_origins = (
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "http://localhost:3001",
+    "http://127.0.0.1:3001",
+)
+_env_cors_origins = [
+    origin.strip()
+    for origin in os.environ.get("CORS_ALLOWED_ORIGINS", "").split(",")
+    if origin.strip()
+]
+
+CORS_ALLOWED_ORIGINS = _env_cors_origins or list(_default_cors_origins)
+CORS_ALLOW_CREDENTIALS = True
 
 
 AUTH_USER_MODEL = "users.User"

--- a/core/settings.py
+++ b/core/settings.py
@@ -4,7 +4,13 @@ import importlib.util
 import os
 from pathlib import Path
 
-from dotenv import load_dotenv
+try:  # pragma: no cover - fallback path exercised only when dependency missing
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - lightweight shim for constrained envs
+    def load_dotenv(*_args, **_kwargs):
+        """Gracefully skip dotenv loading when the optional dependency is absent."""
+
+        return False
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,12 @@ services:
       POSTGRES_PORT: "5432"
       DJANGO_SUPERUSER_EMAIL: admin@example.com
       DJANGO_SUPERUSER_PASSWORD: Passw0rd!
+      REDIS_URL: redis://redis:6379/0
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_started
     ports:
       - "8000:8000"
     volumes:
@@ -33,6 +36,10 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,8 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
   redis:
-    image: redis:7-alpine
+    build:
+      context: ./docker/redis
     ports:
       - "6379:6379"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
   redis:
-    build:
-      context: ./docker/redis
+    image: public.ecr.aws/docker/library/redis:7-alpine
     ports:
       - "6379:6379"
 

--- a/docker/redis/Dockerfile
+++ b/docker/redis/Dockerfile
@@ -1,9 +1,0 @@
-FROM debian:12-slim
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends redis-server \
-    && rm -rf /var/lib/apt/lists/*
-
-EXPOSE 6379
-
-CMD ["redis-server", "/etc/redis/redis.conf"]

--- a/docker/redis/Dockerfile
+++ b/docker/redis/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:12-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends redis-server \
+    && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 6379
+
+CMD ["redis-server", "/etc/redis/redis.conf"]

--- a/messaging/consumers.py
+++ b/messaging/consumers.py
@@ -35,6 +35,21 @@ class ThreadConsumer(AsyncJsonWebsocketConsumer):
             )
         await super().disconnect(code)
 
+    async def receive_json(self, content, **kwargs):  # type: ignore[override]
+        """Handle client-originating messages.
+
+        The frontend currently only uses the websocket for push updates, but
+        some clients still send keepalive or acknowledgement frames. Dropping
+        them silently avoids ``NotImplementedError`` disconnects raised by the
+        base class while keeping room for future message types.
+        """
+
+        del kwargs
+        event = content.get("event")
+        if event == "ping":
+            await self.send_json({"event": "pong"})
+        # Ignore unrecognised payloads to keep the connection alive.
+
     async def message_created(self, event):
         await self.send_json({"event": "message.created", "message": event["payload"]})
 

--- a/messaging/consumers.py
+++ b/messaging/consumers.py
@@ -1,0 +1,50 @@
+"""WebSocket consumers handling thread events."""
+
+from __future__ import annotations
+
+from channels.db import database_sync_to_async
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+from django.db.models import Q
+
+from .models import Thread
+
+
+class ThreadConsumer(AsyncJsonWebsocketConsumer):
+    """Broadcast new messages and read receipts to thread participants."""
+
+    thread_group_name: str
+
+    async def connect(self):
+        user = self.scope.get("user")
+        thread_id = self.scope["url_route"]["kwargs"]["thread_id"]
+        if not user or not user.is_authenticated:
+            await self.close(code=4401)
+            return
+        thread = await self._get_thread_for_user(thread_id, user.id)
+        if not thread:
+            await self.close(code=4403)
+            return
+        self.thread_group_name = f"thread_{thread.id}"
+        await self.channel_layer.group_add(self.thread_group_name, self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, code):  # type: ignore[override]
+        if hasattr(self, "thread_group_name"):
+            await self.channel_layer.group_discard(
+                self.thread_group_name, self.channel_name
+            )
+        await super().disconnect(code)
+
+    async def message_created(self, event):
+        await self.send_json({"event": "message.created", "message": event["payload"]})
+
+    async def message_read(self, event):
+        await self.send_json({"event": "message.read", "message": event["payload"]})
+
+    @database_sync_to_async
+    def _get_thread_for_user(self, thread_id: str, user_id: int):
+        return (
+            Thread.objects.filter(id=thread_id)
+            .filter(Q(collaborator__user_id=user_id) | Q(agent__user_id=user_id))
+            .first()
+        )

--- a/messaging/routing.py
+++ b/messaging/routing.py
@@ -1,0 +1,12 @@
+"""WebSocket routing configuration for messaging."""
+
+from django.urls import re_path
+
+from .consumers import ThreadConsumer
+
+websocket_urlpatterns = [
+    re_path(
+        r"^ws/messaging/threads/(?P<thread_id>[0-9a-fA-F\-]{36})/$",
+        ThreadConsumer.as_asgi(),
+    ),
+]

--- a/messaging/serializers.py
+++ b/messaging/serializers.py
@@ -220,6 +220,8 @@ class MessageSerializer(serializers.ModelSerializer):
     lookups.
     """
 
+    thread = serializers.UUIDField(source="thread_id", read_only=True)
+    sender = serializers.UUIDField(source="sender_id", read_only=True)
     sender_email = serializers.EmailField(source="sender.email", read_only=True)
 
     class Meta:

--- a/messaging/serializers.py
+++ b/messaging/serializers.py
@@ -5,6 +5,8 @@ thread creation rules. Inline comments call out non-obvious business rules such
 as de-duplication and access restrictions.
 """
 
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
 from django.db import transaction
 from rest_framework import serializers
 
@@ -291,6 +293,13 @@ class MessageCreateSerializer(serializers.ModelSerializer):
         )
         thread.last_message_at = message.created_at
         thread.save(update_fields=["last_message_at", "updated_at"])
+        channel_layer = get_channel_layer()
+        if channel_layer:
+            payload = MessageSerializer(message).data
+            async_to_sync(channel_layer.group_send)(
+                f"thread_{thread.id}",
+                {"type": "message_created", "payload": payload},
+            )
         return message
 
 
@@ -320,4 +329,11 @@ class MessageReadSerializer(serializers.ModelSerializer):
 
         instance.is_read = validated_data.get("is_read", True)
         instance.save(update_fields=["is_read", "updated_at"])
+        channel_layer = get_channel_layer()
+        if channel_layer:
+            payload = MessageSerializer(instance).data
+            async_to_sync(channel_layer.group_send)(
+                f"thread_{instance.thread_id}",
+                {"type": "message_read", "payload": payload},
+            )
         return instance

--- a/notifications/consumers.py
+++ b/notifications/consumers.py
@@ -1,0 +1,35 @@
+"""WebSocket consumers pushing notification updates."""
+
+from __future__ import annotations
+
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+
+
+class NotificationConsumer(AsyncJsonWebsocketConsumer):
+    """Stream notification changes to authenticated users."""
+
+    group_name: str
+
+    async def connect(self):
+        user = self.scope.get("user")
+        if not user or not user.is_authenticated:
+            await self.close(code=4401)
+            return
+        self.group_name = f"user_{user.id}"
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, code):  # type: ignore[override]
+        if hasattr(self, "group_name"):
+            await self.channel_layer.group_discard(self.group_name, self.channel_name)
+        await super().disconnect(code)
+
+    async def notification_created(self, event):
+        await self.send_json(
+            {"event": "notification.created", "notification": event["payload"]}
+        )
+
+    async def notification_updated(self, event):
+        await self.send_json(
+            {"event": "notification.updated", "notification": event["payload"]}
+        )

--- a/notifications/routing.py
+++ b/notifications/routing.py
@@ -1,0 +1,9 @@
+"""WebSocket routing configuration for notifications."""
+
+from django.urls import re_path
+
+from .consumers import NotificationConsumer
+
+websocket_urlpatterns = [
+    re_path(r"^ws/notifications/$", NotificationConsumer.as_asgi()),
+]

--- a/notifications/serializers.py
+++ b/notifications/serializers.py
@@ -4,6 +4,8 @@ Serializers transform notification model instances into the shape expected by
 the API clients and validate partial updates such as read-state toggles.
 """
 
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
 from rest_framework import serializers
 
 from .models import Notification
@@ -49,3 +51,15 @@ class NotificationReadSerializer(serializers.ModelSerializer):
 
         model = Notification
         fields = ("is_read",)
+
+    def update(self, instance, validated_data):
+        instance.is_read = validated_data.get("is_read", instance.is_read)
+        instance.save(update_fields=["is_read", "updated_at"])
+        channel_layer = get_channel_layer()
+        if channel_layer:
+            payload = NotificationSerializer(instance).data
+            async_to_sync(channel_layer.group_send)(
+                f"user_{instance.user_id}",
+                {"type": "notification_updated", "payload": payload},
+            )
+        return instance

--- a/notifications/signals.py
+++ b/notifications/signals.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import logging
 
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from .emails import send_notification_email
 from .models import Notification
+from .serializers import NotificationSerializer
 
 logger = logging.getLogger(__name__)
 
@@ -23,3 +26,11 @@ def trigger_notification_email(sender, instance: Notification, created: bool, **
         send_notification_email(instance)
     except Exception:  # pragma: no cover - defensive
         logger.exception("Unhandled error while sending notification email")
+
+    channel_layer = get_channel_layer()
+    if channel_layer:
+        payload = NotificationSerializer(instance).data
+        async_to_sync(channel_layer.group_send)(
+            f"user_{instance.user_id}",
+            {"type": "notification_created", "payload": payload},
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,9 @@ djangorestframework_simplejwt==5.5.1  # JWT authentication backend for DRF
 drf-yasg==1.21.10  # OpenAPI schema generation for interactive docs
 uritemplate==4.2.0  # URL template expansion required by drf-yasg
 PyJWT==2.10.1  # Explicit pin aligned with SimpleJWT to avoid compatibility drift
+channels==4.1.0  # ASGI support enabling WebSocket consumers
+channels-redis==4.2.0  # Redis-backed channel layer for horizontal scaling
+daphne==4.1.2  # ASGI server used to serve HTTP and WebSocket traffic
 
 # Application utilities and runtime extras
 Faker==37.8.0  # Generates sample data for management commands

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ PyJWT==2.10.1  # Explicit pin aligned with SimpleJWT to avoid compatibility drif
 channels==4.1.0  # ASGI support enabling WebSocket consumers
 channels-redis==4.2.0  # Redis-backed channel layer for horizontal scaling
 daphne==4.1.2  # ASGI server used to serve HTTP and WebSocket traffic
+django-cors-headers==4.6.0  # CORS middleware permitting the frontend SPA to call the API
 
 # Application utilities and runtime extras
 Faker==37.8.0  # Generates sample data for management commands

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -10,9 +10,8 @@ APP_PORT="${PORT:-8000}"
 # Always operate from the Django project root.
 cd /app/
 
-# Launch Gunicorn with a shared memory worker tmp directory to improve
-# performance on Alpine-based images.
-exec /py/bin/gunicorn \
-    --worker-tmp-dir /dev/shm \
-    --bind "0.0.0.0:${APP_PORT}" \
-    core.wsgi:application
+# Launch Daphne so the container can serve both HTTP and WebSocket traffic.
+exec /py/bin/daphne \
+    --bind "0.0.0.0" \
+    --port "${APP_PORT}" \
+    core.asgi:application


### PR DESCRIPTION
## Summary
- add Django Channels, Redis channel layer configuration, and a JWT-aware ASGI middleware stack to serve websocket traffic
- implement websocket consumers and routing for messaging threads and notification streams, emitting events from serializers and signals
- update Docker services and entrypoint to run Daphne alongside a Redis service for realtime delivery

## Testing
- `pytest`
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_68d46f1911f0832ea9718a39547f2192