### PR TITLE
Add CI badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # Sponsors Club Monorepo
 
+<p align="center">
+  <a href="https://github.com/your-github-org/sponsors-club-backend/actions/workflows/ci.yml?query=workflow%3ACI">
+    <img src="https://github.com/your-github-org/sponsors-club-backend/actions/workflows/ci.yml/badge.svg?branch=main&job=build" alt="Statut du build" />
+  </a>
+  <a href="https://github.com/your-github-org/sponsors-club-backend/actions/workflows/ci.yml?query=workflow%3ACI">
+    <img src="https://github.com/your-github-org/sponsors-club-backend/actions/workflows/ci.yml/badge.svg?branch=main&job=lint" alt="Statut du lint" />
+  </a>
+  <a href="https://github.com/your-github-org/sponsors-club-backend/actions/workflows/ci.yml?query=workflow%3ACI">
+    <img src="https://github.com/your-github-org/sponsors-club-backend/actions/workflows/ci.yml/badge.svg?branch=main&job=tests" alt="Statut des tests" />
+  </a>
+  <a href="https://github.com/your-github-org/sponsors-club-backend/actions/workflows/ci.yml?query=workflow%3ACI">
+    <img src="https://github.com/your-github-org/sponsors-club-backend/actions/workflows/ci.yml/badge.svg?branch=main&job=containerize" alt="Statut du packaging Docker" />
+  </a>
+</p>
+
+> Remplacez `your-github-org` par votre organisation ou votre nom d'utilisateur GitHub si nécessaire.
+
 This repository now hosts both the historical Django backend and a brand new Next.js + Tailwind frontend scaffold.
 
 - [`backend/`](backend/README.md) contains the existing Django project.


### PR DESCRIPTION
## Summary
- add GitHub Actions badges for each job defined in the CI workflow
- document that the organisation slug in the badge URLs should be replaced as needed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d88224b3c4832e887e08dd176a7661