### PR TITLE
feat: derive agent display name during registration

### DIFF
--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -11,8 +11,8 @@ This service combines Django session auth with JWT-based APIs so both the admin 
 ## Registration workflow
 
 1. `POST /api/users/register/` hits `RegisterView`, which permits anonymous access and validates payloads with `RegisterSerializer`.
-2. Agents must supply a `display_name`; collaborator-specific fields are optional and reserved for future onboarding flows.
-3. During creation the serializer persists the `users.User`, hashes the password, and auto-creates an `AgentProfile` when the account type is `AGENT`.
+2. During creation the serializer persists the `users.User`, hashes the password, and auto-creates an `AgentProfile` when the account type is `AGENT`.
+3. Agent profiles derive their `display_name` from the supplied first/last name or fall back to the email address when names are omitted.
 4. The response is normalized through `UserSerializer`, returning the canonical user fields for immediate client use.
 
 ```http
@@ -23,7 +23,6 @@ Content-Type: application/json
   "email": "agent@example.com",
   "password": "test1234",
   "account_type": "AGENT",
-  "display_name": "Example Agency",
   "first_name": "Ada",
   "last_name": "Lovelace"
 }

--- a/docs/domain/users.md
+++ b/docs/domain/users.md
@@ -17,9 +17,10 @@ endpoints. It also exposes JWT login/refresh routes via DRF Simple JWT.
 
 ## Serializers and workflows
 - `RegisterSerializer` handles both agent and collaborator sign-ups. Agent
-  registrations require a `display_name` and automatically create an
-  `AgentProfile`. (Collaborator onboarding into organisations is managed by the
-  organisations app.)
+  registrations automatically create an `AgentProfile` whose display name
+  defaults to the provided first/last name combination or the user's email when
+  names are omitted. (Collaborator onboarding into organisations is managed by
+  the organisations app.)
 - `MeUpdateSerializer` updates core user fields and, when provided, synchronises
   the agent profile's `display_name`.
 - `RolesDataBuilder` collects the authenticated user's collaborations and agent

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -43,11 +43,6 @@ class RegisterSerializer(serializers.ModelSerializer):
     """Handle registration for both agent and collaborator accounts."""
 
     password = serializers.CharField(write_only=True)
-    display_name = serializers.CharField(
-        write_only=True,
-        required=False,
-        allow_blank=True,
-    )
     is_self_represented = serializers.BooleanField(
         write_only=True,
         required=False,
@@ -60,7 +55,6 @@ class RegisterSerializer(serializers.ModelSerializer):
             "email",
             "password",
             "account_type",
-            "display_name",
             "first_name",
             "last_name",
             "is_self_represented",
@@ -70,30 +64,19 @@ class RegisterSerializer(serializers.ModelSerializer):
         )
         read_only_fields = ("id",)
 
-    def validate(self, attrs):
-        """Ensure required companion fields are provided per account type."""
-        account_type = attrs.get("account_type", User.AccountType.AGENT)
-        display_name = attrs.get("display_name")
-        if account_type == User.AccountType.AGENT and not display_name:
-            raise serializers.ValidationError(
-                {"display_name": "This field is required for agent accounts."}
-            )
-        return attrs
-
     @transaction.atomic
     def create(self, validated_data):
         """Create a user and any related agent or collaborator records."""
-        display_name = validated_data.pop("display_name", None)
         is_self_represented = validated_data.pop("is_self_represented", False)
         password = validated_data.pop("password")
         user = User.objects.create_user(password=password, **validated_data)
         if user.account_type == User.AccountType.AGENT:
             default_display_name = (
-                f"{user.first_name} {user.last_name}".strip() or user.email
-            )
+                f"{user.first_name} {user.last_name}"
+            ).strip() or user.email
             AgentProfile.objects.create(
                 user=user,
-                display_name=display_name or default_display_name,
+                display_name=default_display_name,
                 is_self_represented=is_self_represented,
             )
         send_email_verification(user)

--- a/users/tests/test_user_api.py
+++ b/users/tests/test_user_api.py
@@ -35,26 +35,12 @@ def test_user_password_hash_updates(user_model):
 
 
 @pytest.mark.django_db
-def test_register_agent_requires_display_name(api_client):
-    url = reverse("users:register")
-    payload = {
-        "email": "newagent@example.com",
-        "password": "pass1234",
-        "account_type": "AGENT",
-    }
-    response = api_client.post(url, payload, format="json")
-    assert response.status_code == 400
-    assert "display_name" in response.data
-
-
-@pytest.mark.django_db
 def test_register_agent_success(api_client, user_model):
     url = reverse("users:register")
     payload = {
         "email": "newagent@example.com",
         "password": "pass1234",
         "account_type": "AGENT",
-        "display_name": "Agent Nouveau",
         "first_name": "Agent",
         "last_name": "Nouveau",
         "phone_country_code": "+33",
@@ -68,6 +54,20 @@ def test_register_agent_success(api_client, user_model):
     assert user.phone_country_code == "+33"
     assert user.phone_number == "0102030405"
     assert user.agent_profile.is_self_represented is True
+
+
+@pytest.mark.django_db
+def test_register_agent_defaults_display_name(api_client, user_model):
+    url = reverse("users:register")
+    payload = {
+        "email": "noname@example.com",
+        "password": "pass1234",
+        "account_type": "AGENT",
+    }
+    response = api_client.post(url, payload, format="json")
+    assert response.status_code == 201
+    user = user_model.objects.get(email="noname@example.com")
+    assert user.agent_profile.display_name == "noname@example.com"
 
 
 @pytest.mark.django_db
@@ -296,7 +296,6 @@ def test_register_serializer_representation(api_client):
             "email": "rep@example.com",
             "password": "pass1234",
             "account_type": "AGENT",
-            "display_name": "Rep Agent",
             "first_name": "Rep",
             "last_name": "Agent",
             "phone_country_code": "+49",


### PR DESCRIPTION
## Summary
- derive agent profile display names from user details during registration so the field is no longer required in the payload
- document the updated registration workflow and defaults for agent profiles
- align registration tests with the new behaviour and cover the email fallback case

## Testing
- pytest -o addopts='' users/tests/test_user_api.py::test_register_agent_success users/tests/test_user_api.py::test_register_agent_defaults_display_name users/tests/test_user_api.py::test_register_serializer_representation -q

------
https://chatgpt.com/codex/tasks/task_e_68d899470350832eb1b8f6968b875fe8