### PR TITLE
Remove agent display name usage

### DIFF
--- a/athletes/admin.py
+++ b/athletes/admin.py
@@ -56,7 +56,8 @@ class AthleteAdmin(admin.ModelAdmin):
     search_fields = (
         "full_name",
         "sport__name",
-        "agent__display_name",
         "agent__user__email",
+        "agent__user__first_name",
+        "agent__user__last_name",
     )
     inlines = (AthletePhotoInline,)

--- a/athletes/tests/test_athletes_api.py
+++ b/athletes/tests/test_athletes_api.py
@@ -69,7 +69,7 @@ def other_agent_user(user_model):
         first_name="Other",
         last_name="Agent",
     )
-    AgentProfile.objects.create(user=user, display_name="Other Agent")
+    AgentProfile.objects.create(user=user)
     return user
 
 

--- a/athletes/tests/test_services.py
+++ b/athletes/tests/test_services.py
@@ -68,7 +68,7 @@ def test_my_athletes_queryset_filters_by_agent(agent_user, user_model):
         first_name="Other",
         last_name="Agent",
     )
-    other_agent = AgentProfile.objects.create(user=other_user, display_name="Other Agent")
+    other_agent = AgentProfile.objects.create(user=other_user)
     create_athlete(agent=other_agent, sport=sport, name="Away Athlete")
 
     queryset = my_athletes_queryset(agent_user.agent_profile)

--- a/conftest.py
+++ b/conftest.py
@@ -273,7 +273,7 @@ def fixture_agent_user(user_model):
         last_name="User",
         account_type=user_model.AccountType.AGENT,
     )
-    AgentProfile.objects.create(user=user, display_name="Agent One")
+    AgentProfile.objects.create(user=user)
     return user
 
 

--- a/contracts/admin.py
+++ b/contracts/admin.py
@@ -68,9 +68,15 @@ class ContractAdmin(admin.ModelAdmin):
 
     list_display = ("title", "organisation", "agent", "status", "effective_date")
     list_filter = ("status", "organisation")
-    # Searching by organisation name or agent display name mirrors the data
-    # request wording we receive from account managers.
-    search_fields = ("title", "organisation__name", "agent__display_name")
+    # Searching by organisation name or agent contact mirrors support requests
+    # received from account managers.
+    search_fields = (
+        "title",
+        "organisation__name",
+        "agent__user__email",
+        "agent__user__first_name",
+        "agent__user__last_name",
+    )
     inlines = [ContractClauseInline]
 
 

--- a/contracts/migrations/0004_update_contract_workflow_models.py
+++ b/contracts/migrations/0004_update_contract_workflow_models.py
@@ -64,7 +64,6 @@ def ensure_contract_agents(apps, schema_editor):
         placeholder_user.save()
         agent = AgentProfile.objects.create(
             user=placeholder_user,
-            display_name="Default Agent",
         )
 
     Contract.objects.filter(agent__isnull=True).update(agent=agent)

--- a/contracts/serializers.py
+++ b/contracts/serializers.py
@@ -41,7 +41,7 @@ class OrganisationSummarySerializer(serializers.ModelSerializer):
 class AgentSummarySerializer(serializers.ModelSerializer):
     """Render a minimal agent representation for contract payloads."""
 
-    name = serializers.CharField(source="name", read_only=True)
+    name = serializers.CharField(read_only=True)
 
     class Meta:
         model = AgentProfile

--- a/contracts/serializers.py
+++ b/contracts/serializers.py
@@ -41,9 +41,11 @@ class OrganisationSummarySerializer(serializers.ModelSerializer):
 class AgentSummarySerializer(serializers.ModelSerializer):
     """Render a minimal agent representation for contract payloads."""
 
+    name = serializers.CharField(source="name", read_only=True)
+
     class Meta:
         model = AgentProfile
-        fields = ("id", "display_name")
+        fields = ("id", "name")
 
 
 class CollaboratorSummarySerializer(serializers.ModelSerializer):

--- a/contracts/views.py
+++ b/contracts/views.py
@@ -227,8 +227,10 @@ class ContractViewSet(
             seen.add(organisation.id)
 
         agents = [
-            {"id": str(agent.id), "display_name": agent.display_name}
-            for agent in AgentProfile.objects.all().order_by("display_name")
+            {"id": str(agent.id), "name": agent.name}
+            for agent in AgentProfile.objects.all()
+            .select_related("user")
+            .order_by("user__first_name", "user__last_name", "user__email")
         ]
 
         statuses = [

--- a/core/management/commands/seed.py
+++ b/core/management/commands/seed.py
@@ -148,7 +148,6 @@ class Command(BaseCommand):
             )
             AgentProfile.objects.create(
                 user=user,
-                display_name=full_name,
                 bio=faker.paragraph(nb_sentences=3),
             )
             # Re-accessing ``user.agent_profile`` ensures the relation is loaded

--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -12,7 +12,7 @@ This service combines Django session auth with JWT-based APIs so both the admin 
 
 1. `POST /api/users/register/` hits `RegisterView`, which permits anonymous access and validates payloads with `RegisterSerializer`.
 2. During creation the serializer persists the `users.User`, hashes the password, and auto-creates an `AgentProfile` when the account type is `AGENT`.
-3. Agent profiles derive their `display_name` from the supplied first/last name or fall back to the email address when names are omitted.
+3. Agent profiles expose a derived name based on the supplied first/last name or, when both are missing, the email address.
 4. The response is normalized through `UserSerializer`, returning the canonical user fields for immediate client use.
 
 ```http
@@ -38,7 +38,7 @@ Tokens are standard SimpleJWT payloads, so extra claims can be injected later wi
 
 ## Self-service endpoints
 
-- **`GET /api/users/me/`** – Returns the authenticated user. `PATCH`/`PUT` accepts `MeUpdateSerializer`, which updates contact fields and synchronizes the agent display name when relevant.
+- **`GET /api/users/me/`** – Returns the authenticated user. `PATCH`/`PUT` accepts `MeUpdateSerializer`, which updates contact fields and toggles the agent profile's self-representation flag when provided.
 - **`GET /api/users/me/roles/`** – Aggregates roles via `RolesDataBuilder`, exposing agent profile details plus a list of organisation collaborations (id, name, role).
 - **`GET /api/users/me/entitlements/`** – Calls `feature_status_for_user` to enumerate feature gates, returning the account type, grant status, upgrade links, and recommended plans. This powers in-app upgrade prompts.
 

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -30,7 +30,6 @@ classDiagram
         +UUID id
         +datetime created_at
         +datetime updated_at
-        +string display_name
         +text bio
         +bool is_self_represented
     }

--- a/docs/domain/users.md
+++ b/docs/domain/users.md
@@ -11,18 +11,18 @@ endpoints. It also exposes JWT login/refresh routes via DRF Simple JWT.
   `phone_country_code`/`phone_number` pair that must be unique when both values
   are present. The model mirrors Django's password hash into a `password_hash`
   field for legacy compatibility. `UserManager` powers email-based creation.
-- **`AgentProfile`** is a one-to-one extension for agent accounts, storing a
-  `display_name`, an `is_self_represented` flag used to tailor the agent
-  experience, and an optional bio.
+- **`AgentProfile`** is a one-to-one extension for agent accounts, storing an
+  `is_self_represented` flag used to tailor the agent experience and an
+  optional bio. The human-friendly name exposed through the API is derived from
+  the related user's first/last name or, when absent, their email address.
 
 ## Serializers and workflows
 - `RegisterSerializer` handles both agent and collaborator sign-ups. Agent
-  registrations automatically create an `AgentProfile` whose display name
-  defaults to the provided first/last name combination or the user's email when
-  names are omitted. (Collaborator onboarding into organisations is managed by
-  the organisations app.)
-- `MeUpdateSerializer` updates core user fields and, when provided, synchronises
-  the agent profile's `display_name`.
+  registrations automatically create an `AgentProfile` and rely on the user
+  record to expose a readable name. (Collaborator onboarding into organisations
+  is managed by the organisations app.)
+- `MeUpdateSerializer` updates core user fields and toggles the agent profile's
+  `is_self_represented` flag when provided.
 - `RolesDataBuilder` collects the authenticated user's collaborations and agent
   info for the `/me/roles/` endpoint, returning a shape validated by
   `RolesSerializer`.
@@ -41,7 +41,7 @@ Routes are mounted under `/api/users/`.
 | `POST` | `/login/` | Obtain JWT access/refresh tokens (Simple JWT). | Public |
 | `POST` | `/refresh/` | Refresh a JWT token pair. | Public |
 | `GET` | `/me/` | Retrieve the authenticated user's profile. | Authenticated |
-| `PUT/PATCH` | `/me/` | Update profile fields and, for agents, display name. | Authenticated |
+| `PUT/PATCH` | `/me/` | Update profile fields and, for agents, representation status. | Authenticated |
 | `GET` | `/me/roles/` | Return agent profile metadata and organisation collaborations. | Authenticated |
 | `GET` | `/me/entitlements/` | Return the user's feature entitlements. | Authenticated |
 

--- a/messaging/serializers.py
+++ b/messaging/serializers.py
@@ -41,7 +41,7 @@ class AgentProfileSummarySerializer(serializers.ModelSerializer):
     underlying user.
     """
 
-    name = serializers.CharField(source="name", read_only=True)
+    name = serializers.CharField(read_only=True)
     user_email = serializers.EmailField(source="user.email", read_only=True)
 
     class Meta:

--- a/messaging/serializers.py
+++ b/messaging/serializers.py
@@ -41,13 +41,14 @@ class AgentProfileSummarySerializer(serializers.ModelSerializer):
     underlying user.
     """
 
+    name = serializers.CharField(source="name", read_only=True)
     user_email = serializers.EmailField(source="user.email", read_only=True)
 
     class Meta:
         """Serializer configuration."""
 
         model = AgentProfile
-        fields = ("id", "display_name", "user_email", "is_self_represented")
+        fields = ("id", "name", "user_email", "is_self_represented")
         ref_name = "MessagingAgentSummary"
 
 

--- a/messaging/tests/test_views_api.py
+++ b/messaging/tests/test_views_api.py
@@ -70,7 +70,6 @@ def test_thread_list_returns_threads_for_agent(
     )
     outsider_profile = AgentProfile.objects.create(
         user=outsider_user,
-        display_name="Other Agent",
     )
     Thread.objects.create(
         collaborator=other_collaborator,
@@ -111,7 +110,6 @@ def test_thread_list_returns_threads_for_collaborator(
     )
     other_agent_profile = AgentProfile.objects.create(
         user=other_agent_user,
-        display_name="Agent Two",
     )
     secondary_thread = Thread.objects.create(
         collaborator=collaborator,
@@ -222,7 +220,6 @@ def test_thread_messages_view_get_denies_non_participant(
     )
     other_agent_profile = AgentProfile.objects.create(
         user=other_agent_user,
-        display_name="Agent Three",
     )
     thread = Thread.objects.create(
         collaborator=collaborator,

--- a/payments/admin.py
+++ b/payments/admin.py
@@ -54,7 +54,9 @@ class SubscriptionAdmin(admin.ModelAdmin):
     list_filter = ("status", "plan")
     search_fields = (
         "organisation__name",
-        "agent__display_name",
+        "agent__user__email",
+        "agent__user__first_name",
+        "agent__user__last_name",
         "stripe_customer_id",
         "stripe_subscription_id",
     )

--- a/payments/tests/test_serializers.py
+++ b/payments/tests/test_serializers.py
@@ -180,7 +180,7 @@ def test_subscription_create_serializer_validates_agent_scope(
         last_name="User",
         account_type=user_model.AccountType.AGENT,
     )
-    agent_profile = AgentProfile.objects.create(user=agent_user, display_name="Agent")
+    agent_profile = AgentProfile.objects.create(user=agent_user)
 
     request = build_request(
         agent_user,
@@ -220,7 +220,7 @@ def test_subscription_create_serializer_rejects_foreign_agent(
         last_name="Two",
         account_type=user_model.AccountType.AGENT,
     )
-    agent_profile = AgentProfile.objects.create(user=agent_user, display_name="Agent Two")
+    agent_profile = AgentProfile.objects.create(user=agent_user)
 
     request = build_request(owner, {})
     serializer = SubscriptionCreateSerializer(
@@ -245,7 +245,7 @@ def test_subscription_create_serializer_allows_staff_to_manage_foreign_agent(
         last_name="Agent",
         account_type=user_model.AccountType.AGENT,
     )
-    agent_profile = AgentProfile.objects.create(user=agent_user, display_name="Managed")
+    agent_profile = AgentProfile.objects.create(user=agent_user)
 
     staff_user = user_model.objects.create_user(
         email="staff@example.com",
@@ -296,7 +296,7 @@ def test_subscription_create_serializer_rejects_multiple_scopes(
     subscription_plan, organisation_owner
 ):
     user, organisation, _ = organisation_owner
-    agent_profile = AgentProfile.objects.create(user=user, display_name="Dual")
+    agent_profile = AgentProfile.objects.create(user=user)
     request = build_request(user, {})
     serializer = SubscriptionCreateSerializer(
         data={
@@ -375,7 +375,7 @@ def test_subscription_create_serializer_update_not_supported(subscription_plan, 
         last_name="Four",
         account_type=user_model.AccountType.AGENT,
     )
-    agent_profile = AgentProfile.objects.create(user=agent_user, display_name="Agent Four")
+    agent_profile = AgentProfile.objects.create(user=agent_user)
     request = build_request(agent_user, {})
     serializer = SubscriptionCreateSerializer(
         data={"plan_id": subscription_plan.id, "agent_id": agent_profile.id},
@@ -399,7 +399,7 @@ def test_stripe_checkout_session_serializer_reuses_subscription_validation(
         last_name="Five",
         account_type=user_model.AccountType.AGENT,
     )
-    agent_profile = AgentProfile.objects.create(user=agent_user, display_name="Agent Five")
+    agent_profile = AgentProfile.objects.create(user=agent_user)
 
     request = build_request(agent_user, {})
     serializer = StripeCheckoutSessionSerializer(

--- a/templates/poc/contracts_agent_revisions.html
+++ b/templates/poc/contracts_agent_revisions.html
@@ -528,7 +528,7 @@
 
         if (state.roles && state.roles.agent_profile) {
             const agentLine = document.createElement('span');
-            agentLine.textContent = `Profil agent : ${state.roles.agent_profile.display_name}`;
+            agentLine.textContent = `Profil agent : ${state.roles.agent_profile.name}`;
             identitySummary.appendChild(agentLine);
         } else {
             const infoLine = document.createElement('span');
@@ -609,7 +609,7 @@
 
         const infoItems = [];
         if (contract.agent) {
-            infoItems.push(`Agent : ${contract.agent.display_name}`);
+            infoItems.push(`Agent : ${contract.agent.name}`);
         }
         if (contract.initiated_by) {
             infoItems.push(`Créé par : ${contract.initiated_by.email}`);

--- a/templates/poc/contracts_editor.html
+++ b/templates/poc/contracts_editor.html
@@ -410,7 +410,7 @@
             parts.push(`Organisation • ${state.contract.organisation.name}`);
         }
         if (state.contract.agent) {
-            parts.push(`Agent • ${state.contract.agent.display_name}`);
+            parts.push(`Agent • ${state.contract.agent.name}`);
         }
         if (state.contract.updated_at) {
             const date = new Date(state.contract.updated_at);

--- a/templates/poc/contracts_overview.html
+++ b/templates/poc/contracts_overview.html
@@ -417,7 +417,7 @@
         for (const item of items) {
             const option = document.createElement('option');
             option.value = item.id;
-            option.textContent = item.name || item.display_name;
+            option.textContent = item.name || item.email;
             select.appendChild(option);
         }
         if (select === organisationSelect) {
@@ -618,7 +618,7 @@
             organisationCell.textContent = contract.organisation ? contract.organisation.name : '—';
 
             const agentCell = document.createElement('td');
-            agentCell.textContent = contract.agent ? contract.agent.display_name : '—';
+            agentCell.textContent = contract.agent ? contract.agent.name : '—';
 
             const updatedCell = document.createElement('td');
             updatedCell.textContent = formatDate(contract.updated_at);

--- a/templates/poc/contracts_review.html
+++ b/templates/poc/contracts_review.html
@@ -406,7 +406,7 @@
             parts.push(`Organisation • ${state.contract.organisation.name}`);
         }
         if (state.contract.agent) {
-            parts.push(`Agent • ${state.contract.agent.display_name}`);
+            parts.push(`Agent • ${state.contract.agent.name}`);
         }
         if (state.contract.updated_at) {
             const date = new Date(state.contract.updated_at);

--- a/templates/poc/messaging.html
+++ b/templates/poc/messaging.html
@@ -683,7 +683,7 @@ function MessageTesterApp() {
                                                 <strong>Collaborateur :</strong> {thread.collaborator?.role || "—"} · {thread.collaborator?.id || "—"}
                                             </div>
                                             <div>
-                                                <strong>Agent :</strong> {thread.agent?.display_name || "—"} · {thread.agent?.id || "—"}
+                                                <strong>Agent :</strong> {thread.agent?.name || "—"} · {thread.agent?.id || "—"}
                                             </div>
                                         </div>
                                         <div className="controls">

--- a/tests/test_conftest_unit.py
+++ b/tests/test_conftest_unit.py
@@ -261,8 +261,9 @@ def test_agent_user_fixture_creates_profile(monkeypatch: pytest.MonkeyPatch) -> 
 
     created_profiles: list[SimpleNamespace] = []
 
-    def fake_profile_create(*, user, display_name, **kwargs):  # noqa: ANN001
-        profile = SimpleNamespace(user=user, display_name=display_name, extra=kwargs)
+    def fake_profile_create(*, user, **kwargs):  # noqa: ANN001
+        profile = SimpleNamespace(user=user, extra=kwargs)
+        profile.name = str(user)
         user.agent_profile = profile
         created_profiles.append(profile)
         return profile
@@ -277,8 +278,7 @@ def test_agent_user_fixture_creates_profile(monkeypatch: pytest.MonkeyPatch) -> 
     agent = _call_fixture(module.fixture_agent_user, user_model)
 
     assert user_model.created and user_model.created[0] is agent
-    assert created_profiles and created_profiles[0].display_name == "Agent One"
-    assert getattr(agent, "agent_profile").display_name == "Agent One"
+    assert created_profiles and getattr(agent, "agent_profile") is created_profiles[0]
 
 
 def test_organisations_setup_fixture_returns_entities(

--- a/users/admin.py
+++ b/users/admin.py
@@ -92,11 +92,16 @@ class UserAdmin(BaseUserAdmin):
 class AgentProfileAdmin(admin.ModelAdmin):
     """Admin configuration for managing agent profiles."""
 
-    list_display = ("user", "display_name", "is_self_represented")
+    list_display = ("user", "agent_name", "is_self_represented")
     list_filter = ("is_self_represented",)
     search_fields = (
-        "display_name",
         "user__email",
         "user__first_name",
         "user__last_name",
     )
+
+    @admin.display(description="Name")
+    def agent_name(self, obj):  # noqa: D401
+        """Return the friendly name derived from the related user."""
+
+        return obj.name

--- a/users/migrations/0001_initial.py
+++ b/users/migrations/0001_initial.py
@@ -144,7 +144,6 @@ class Migration(migrations.Migration):
                 ),
                 ("created_at", models.DateTimeField(auto_now_add=True)),
                 ("updated_at", models.DateTimeField(auto_now=True)),
-                ("display_name", models.CharField(max_length=255)),
                 ("bio", models.TextField(blank=True)),
                 (
                     "user",

--- a/users/models.py
+++ b/users/models.py
@@ -104,8 +104,8 @@ class User(BaseModel, AbstractBaseUser, PermissionsMixin):
 
     def __str__(self):
         """Return the most informative representation for administrators."""
-        display_name = f"{self.first_name} {self.last_name}".strip()
-        return display_name or self.email
+        full_name = f"{self.first_name} {self.last_name}".strip()
+        return full_name or self.email
 
     def set_password(self, raw_password):
         """Persist the password hash on both Django and legacy fields."""
@@ -129,14 +129,17 @@ class AgentProfile(BaseModel):
     user = models.OneToOneField(
         User, on_delete=models.CASCADE, related_name="agent_profile"
     )
-    display_name = models.CharField(max_length=255)
     bio = models.TextField(blank=True)
     is_self_represented = models.BooleanField(default=False)
 
     def __str__(self):
-        """Return the display name or fall back to the related user."""
-        if self.display_name:
-            return str(self.display_name)
+        """Return the related user's preferred representation."""
+        return str(self.user)
+
+    @property
+    def name(self) -> str:
+        """Return a human-friendly representation for API consumers."""
+
         return str(self.user)
 
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -71,12 +71,8 @@ class RegisterSerializer(serializers.ModelSerializer):
         password = validated_data.pop("password")
         user = User.objects.create_user(password=password, **validated_data)
         if user.account_type == User.AccountType.AGENT:
-            default_display_name = (
-                f"{user.first_name} {user.last_name}"
-            ).strip() or user.email
             AgentProfile.objects.create(
                 user=user,
-                display_name=default_display_name,
                 is_self_represented=is_self_represented,
             )
         send_email_verification(user)
@@ -90,7 +86,6 @@ class RegisterSerializer(serializers.ModelSerializer):
 class MeUpdateSerializer(serializers.ModelSerializer):
     """Allow the authenticated user to update their profile details."""
 
-    display_name = serializers.CharField(required=False, allow_blank=True)
     is_self_represented = serializers.BooleanField(required=False)
 
     class Meta:
@@ -102,13 +97,11 @@ class MeUpdateSerializer(serializers.ModelSerializer):
             "phone_country_code",
             "phone_number",
             "date_of_birth",
-            "display_name",
             "is_self_represented",
         )
 
     def update(self, instance, validated_data):
         """Update the user object and related agent profile when needed."""
-        display_name = validated_data.pop("display_name", None)
         is_self_represented = validated_data.pop("is_self_represented", None)
         update_fields = []
         for attr, value in validated_data.items():
@@ -122,15 +115,12 @@ class MeUpdateSerializer(serializers.ModelSerializer):
 
         if (
             instance.account_type == User.AccountType.AGENT
-            and (display_name is not None or is_self_represented is not None)
+            and is_self_represented is not None
         ):
             agent_profile, _ = AgentProfile.objects.get_or_create(
                 user=instance,
             )
             profile_updates: list[str] = []
-            if display_name is not None:
-                agent_profile.display_name = display_name
-                profile_updates.append("display_name")
             if is_self_represented is not None:
                 agent_profile.is_self_represented = is_self_represented
                 profile_updates.append("is_self_represented")
@@ -146,13 +136,20 @@ class MeUpdateSerializer(serializers.ModelSerializer):
         if instance.account_type == User.AccountType.AGENT:
             agent_profile = (
                 AgentProfile.objects.filter(user=instance)
-                .only("id", "display_name", "is_self_represented")
+                .select_related("user")
+                .only(
+                    "id",
+                    "is_self_represented",
+                    "user__first_name",
+                    "user__last_name",
+                    "user__email",
+                )
                 .first()
             )
             if agent_profile is not None:
                 data["agent_profile"] = {
                     "id": str(agent_profile.id),
-                    "display_name": agent_profile.display_name,
+                    "name": agent_profile.name,
                     "is_self_represented": agent_profile.is_self_represented,
                 }
         return data
@@ -191,7 +188,7 @@ class RolesDataBuilder:
         if agent_profile is not None:
             agent_info = {
                 "id": str(agent_profile.id),
-                "display_name": agent_profile.display_name,
+                "name": agent_profile.name,
                 "is_self_represented": agent_profile.is_self_represented,
             }
 

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -24,9 +24,10 @@ def test_user_save_normalises_blank_phone_fields(user_model):
 @pytest.mark.django_db
 def test_agent_profile_str_falls_back_to_user_email(user_model):
     user = user_model.objects.create_user(email="fallback@example.com", password="pass1234")
-    profile = AgentProfile.objects.create(user=user, display_name="")
+    profile = AgentProfile.objects.create(user=user)
 
     assert str(profile) == str(user)
+    assert profile.name == str(user)
 
 
 @pytest.mark.django_db

--- a/users/tests/test_user_api.py
+++ b/users/tests/test_user_api.py
@@ -50,14 +50,15 @@ def test_register_agent_success(api_client, user_model):
     response = api_client.post(url, payload, format="json")
     assert response.status_code == 201
     user = user_model.objects.get(email="newagent@example.com")
-    assert AgentProfile.objects.filter(user=user, display_name="Agent Nouveau").exists()
+    assert AgentProfile.objects.filter(user=user).exists()
+    assert user.agent_profile.name == "Agent Nouveau"
     assert user.phone_country_code == "+33"
     assert user.phone_number == "0102030405"
     assert user.agent_profile.is_self_represented is True
 
 
 @pytest.mark.django_db
-def test_register_agent_defaults_display_name(api_client, user_model):
+def test_register_agent_defaults_name(api_client, user_model):
     url = reverse("users:register")
     payload = {
         "email": "noname@example.com",
@@ -67,7 +68,7 @@ def test_register_agent_defaults_display_name(api_client, user_model):
     response = api_client.post(url, payload, format="json")
     assert response.status_code == 201
     user = user_model.objects.get(email="noname@example.com")
-    assert user.agent_profile.display_name == "noname@example.com"
+    assert user.agent_profile.name == "noname@example.com"
 
 
 @pytest.mark.django_db
@@ -110,7 +111,6 @@ def test_me_update_updates_fields(api_client, agent_user):
         "email": "updated@example.com",
         "first_name": "Updated",
         "last_name": "Name",
-        "display_name": "Updated Agent",
         "phone_country_code": "+1",
         "phone_number": "5551112222",
         "is_self_represented": True,
@@ -121,26 +121,12 @@ def test_me_update_updates_fields(api_client, agent_user):
     assert agent_user.email == "updated@example.com"
     assert agent_user.first_name == "Updated"
     assert agent_user.last_name == "Name"
-    assert agent_user.agent_profile.display_name == "Updated Agent"
+    assert agent_user.agent_profile.name == "Updated Name"
     assert agent_user.agent_profile.is_self_represented is True
     assert agent_user.phone_country_code == "+1"
     assert agent_user.phone_number == "5551112222"
     assert response.data["agent_profile"]["is_self_represented"] is True
-
-
-@pytest.mark.django_db
-def test_me_update_display_name_only(api_client, agent_user):
-    serializer = MeUpdateSerializer(
-        agent_user,
-        data={"display_name": "Solo Update"},
-        partial=True,
-        context={"request": None},
-    )
-    assert serializer.is_valid()
-    serializer.save()
-    agent_user.refresh_from_db()
-    assert agent_user.agent_profile.display_name == "Solo Update"
-    assert agent_user.agent_profile.is_self_represented is False
+    assert response.data["agent_profile"]["name"] == "Updated Name"
 
 
 @pytest.mark.django_db
@@ -189,9 +175,7 @@ def test_roles_builder_with_agent_and_owner(agent_user, organisations_setup):
     builder = RolesDataBuilder(agent_user)
     data = builder.build()
     assert data["is_agent"] is True
-    assert (
-        data["agent_profile"]["display_name"] == agent_user.agent_profile.display_name
-    )
+    assert data["agent_profile"]["name"] == agent_user.agent_profile.name
     assert data["agent_profile"]["is_self_represented"] is False
 
     # Add collaborator membership to cover collaboration branch
@@ -277,7 +261,7 @@ def test_user_save_updates_password_hash(user_model):
 
 @pytest.mark.django_db
 def test_agent_profile_str(agent_user):
-    assert str(agent_user.agent_profile) == agent_user.agent_profile.display_name
+    assert str(agent_user.agent_profile) == agent_user.agent_profile.name
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- remove the `display_name` field from agent profiles and derive names from the linked user instead
- update serializers, admin, API responses, templates, and documentation to expose the derived name
- refresh tests and seed data to work without the legacy field

## Testing
- pytest *(fails: missing websocket consumer ASGI helpers and the `stripe` dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a47a4c54832e8c93b93ab75f8939