### PR TITLE
Add slug-based athlete retrieval endpoint and simplify collaborator role payload

### DIFF
--- a/athletes/tests/test_athletes_api.py
+++ b/athletes/tests/test_athletes_api.py
@@ -97,6 +97,16 @@ def test_athlete_str(athlete):
 
 
 @pytest.mark.django_db
+def test_retrieve_athlete_by_slug(api_client, athlete):
+    url = reverse("athlete-by-slug", kwargs={"slug": athlete.slug})
+    response = api_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["id"] == str(athlete.id)
+    assert response.data["slug"] == athlete.slug
+    assert response.data["full_name"] == athlete.full_name
+
+
+@pytest.mark.django_db
 def test_is_agent_user_permission(agent_user, user_model):
     permission = IsAgentUser()
     factory = APIRequestFactory()

--- a/athletes/urls.py
+++ b/athletes/urls.py
@@ -6,6 +6,7 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from .views import (
+    AthleteBySlugView,
     AthletePhotoListView,
     AthleteViewSet,
     MyAthletesView,
@@ -22,6 +23,11 @@ urlpatterns = [
     path("me/athletes/", MyAthletesView.as_view(), name="my-athletes"),
     path("sports/", SportListView.as_view(), name="sports-list"),
     path("sports/<uuid:sport_id>/disciplines/", SportDisciplinesView.as_view(), name="sport-disciplines"),
+    path(
+        "athletes/slug/<slug:slug>/",
+        AthleteBySlugView.as_view(),
+        name="athlete-by-slug",
+    ),
     path(
         "athletes/<uuid:athlete_id>/photos/",
         AthletePhotoListView.as_view(),

--- a/athletes/views.py
+++ b/athletes/views.py
@@ -13,6 +13,7 @@ from .models import Athlete, Sport
 from .permissions import CanViewAthlete, IsAgentUser, IsAthleteOwner, IsCollaboratorUser
 from .serializers import (
     AthletePhotoSerializer,
+    AthletePublicSerializer,
     AthleteSerializer,
     SportDisciplineSerializer,
     SportSerializer,
@@ -80,6 +81,23 @@ class AthleteViewSet(viewsets.ModelViewSet):
                 validated updates for the athlete.
         """
         serializer.save()
+
+
+class AthleteBySlugView(generics.RetrieveAPIView):
+    """Retrieve an athlete profile using its slug identifier."""
+
+    permission_classes = (permissions.AllowAny,)
+    serializer_class = AthletePublicSerializer
+    lookup_field = "slug"
+
+    def get_queryset(self):
+        """Return athletes with related data eager loaded for public display."""
+
+        return (
+            Athlete.objects.select_related("sport", "agent__user")
+            .prefetch_related("disciplines", "photos")
+            .all()
+        )
 
 
 class MyAthletesView(generics.ListAPIView):

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -196,7 +196,6 @@ class RolesDataBuilder:
             {
                 "id": str(collaboration.id),
                 "organisation_id": str(collaboration.organisation_id),
-                "organisation_name": collaboration.organisation.name,
                 "role": collaboration.role,
             }
             for collaboration in Collaborator.objects.filter(

--- a/users/tests/test_user_api.py
+++ b/users/tests/test_user_api.py
@@ -168,6 +168,7 @@ def test_roles_endpoint_includes_collaborations(
     assert response.data["collaborations"][0]["organisation_id"] == str(
         organisations_setup["organisation"].id
     )
+    assert "organisation_name" not in response.data["collaborations"][0]
 
 
 @pytest.mark.django_db
@@ -188,6 +189,7 @@ def test_roles_builder_with_agent_and_owner(agent_user, organisations_setup):
     data = builder.build()
     assert len(data["collaborations"]) == 1
     assert data["agent_profile"]["is_self_represented"] is False
+    assert "organisation_name" not in data["collaborations"][0]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- add a slug-based athlete endpoint that returns the public serializer
- wire the route and cover it with integration tests
- drop the organisation_name field from collaborator roles and add regression coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9d79b47d8832e90dfdec4079da57a