### PR TITLE
Add wait_for_db management command for Docker startup

### DIFF
--- a/core/management/commands/wait_for_db.py
+++ b/core/management/commands/wait_for_db.py
@@ -1,0 +1,26 @@
+"""Django command to wait for the database to be available."""
+
+import time
+
+from psycopg2 import OperationalError as Psycopg2OpError
+
+from django.core.management.base import BaseCommand
+from django.db.utils import OperationalError
+
+
+class Command(BaseCommand):
+    """Django command to wait for database."""
+
+    def handle(self, *args, **options):
+        """Entrypoint for command."""
+        self.stdout.write("Waiting for database...")
+        db_up = False
+        while db_up is False:
+            try:
+                self.check(databases=["default"])
+                db_up = True
+            except (Psycopg2OpError, OperationalError):
+                self.stdout.write("Database unavailable, waiting 1 second...")
+                time.sleep(1)
+
+        self.stdout.write(self.style.SUCCESS("Database available!"))

--- a/core/management/commands/wait_for_db.py
+++ b/core/management/commands/wait_for_db.py
@@ -5,22 +5,33 @@ import time
 from psycopg2 import OperationalError as Psycopg2OpError
 
 from django.core.management.base import BaseCommand
+from django.db import connections
 from django.db.utils import OperationalError
 
 
 class Command(BaseCommand):
     """Django command to wait for database."""
 
+    DEFAULT_SLEEP_SECONDS = 1
+    MAX_SLEEP_SECONDS = 5
+
     def handle(self, *args, **options):
         """Entrypoint for command."""
         self.stdout.write("Waiting for database...")
-        db_up = False
-        while db_up is False:
+
+        sleep_seconds = self.DEFAULT_SLEEP_SECONDS
+        while True:
+            connection = connections["default"]
             try:
-                self.check(databases=["default"])
-                db_up = True
+                connection.ensure_connection()
             except (Psycopg2OpError, OperationalError):
-                self.stdout.write("Database unavailable, waiting 1 second...")
-                time.sleep(1)
+                self.stdout.write(
+                    f"Database unavailable, waiting {sleep_seconds} second(s)..."
+                )
+                time.sleep(sleep_seconds)
+                sleep_seconds = min(sleep_seconds * 2, self.MAX_SLEEP_SECONDS)
+            else:
+                connection.close()
+                break
 
         self.stdout.write(self.style.SUCCESS("Database available!"))

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -6,6 +6,9 @@ set -e
 # Run commands from the Django project root inside the container.
 cd /app/
 
+# Ensure the database is available before running migrations.
+/py/bin/python manage.py wait_for_db
+
 # Generate any new migration files and apply outstanding migrations.
 /py/bin/python manage.py makemigrations
 /py/bin/python manage.py migrate --noinput


### PR DESCRIPTION
## Summary
- add a Django management command that waits for the database connection to become available
- ensure the Docker migrate script runs the new wait command before migrations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fb8705e57c832e91bd8f4111747c57